### PR TITLE
feat(api): attendance endpoints + health data-source reporting

### DIFF
--- a/apps/api/sql/002_attendance.sql
+++ b/apps/api/sql/002_attendance.sql
@@ -1,0 +1,17 @@
+-- WorkSight attendance schema. Aligns with @worksight/common AttendanceRecord.
+-- Apply after 001_core.sql:
+--   psql "$DATABASE_URL" -f apps/api/sql/002_attendance.sql
+
+CREATE TABLE IF NOT EXISTS attendance (
+  system_id    UUID PRIMARY KEY,
+  employee_id  UUID NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+  date         DATE NOT NULL,
+  check_in     TIMESTAMPTZ,
+  check_out    TIMESTAMPTZ,
+  hours_worked NUMERIC(5,2),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (employee_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS attendance_employee_id_idx ON attendance (employee_id);
+CREATE INDEX IF NOT EXISTS attendance_date_idx ON attendance (date DESC);

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,7 +1,10 @@
 import { Controller, Get, Header } from '@nestjs/common';
+import { DatabaseService } from './db/database.service';
 
 @Controller()
 export class AppController {
+  constructor(private readonly db: DatabaseService) {}
+
   @Get()
   getHello(): string {
     return `hello`;
@@ -14,7 +17,15 @@ export class AppController {
   }
 
   @Get('health')
-  health() {
-    return { status: 'ok', uptime: process.uptime() };
+  async health() {
+    if (!this.db.enabled) {
+      return { status: 'ok', uptime: process.uptime(), database: 'fixtures' };
+    }
+    try {
+      await this.db.query('SELECT 1');
+      return { status: 'ok', uptime: process.uptime(), database: 'postgres' };
+    } catch {
+      return { status: 'degraded', uptime: process.uptime(), database: 'unreachable' };
+    }
   }
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AttendanceModule } from './attendance/attendance.module';
 import { DatabaseModule } from './db/database.module';
 import { TasksModule } from './tasks/tasks.module';
 import { UsersModule } from './users/users.module';
 
 @Module({
-  imports: [DatabaseModule, UsersModule, TasksModule],
+  imports: [DatabaseModule, UsersModule, TasksModule, AttendanceModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/api/src/attendance/attendance.controller.ts
+++ b/apps/api/src/attendance/attendance.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import type { AttendanceRecord, AttendanceStats } from '@worksight/common';
+import { AttendanceService } from './attendance.service';
+
+@Controller('attendance')
+export class AttendanceController {
+  constructor(private readonly attendanceService: AttendanceService) {}
+
+  @Get()
+  getAll(@Query('employee_id') employeeId?: string): Promise<AttendanceRecord[]> {
+    return this.attendanceService.findAll(employeeId);
+  }
+
+  @Get('stats/:employeeId')
+  getStats(@Param('employeeId') employeeId: string): Promise<AttendanceStats> {
+    return this.attendanceService.getStatsForEmployee(employeeId);
+  }
+}

--- a/apps/api/src/attendance/attendance.module.ts
+++ b/apps/api/src/attendance/attendance.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AttendanceController } from './attendance.controller';
+import { AttendanceService } from './attendance.service';
+
+@Module({
+  controllers: [AttendanceController],
+  providers: [AttendanceService],
+})
+export class AttendanceModule {}

--- a/apps/api/src/attendance/attendance.service.spec.ts
+++ b/apps/api/src/attendance/attendance.service.spec.ts
@@ -1,0 +1,41 @@
+import { Attendance } from '@worksight/common';
+import type { WorksightRepository } from '../db/worksight.repository';
+import { AttendanceService } from './attendance.service';
+
+describe('AttendanceService', () => {
+  let service: AttendanceService;
+
+  beforeEach(() => {
+    const fixturesOnly = { enabled: false } as WorksightRepository;
+    service = new AttendanceService(fixturesOnly);
+  });
+
+  it('returns the shared attendance fixtures', async () => {
+    await expect(service.findAll()).resolves.toEqual(Attendance);
+  });
+
+  it('filters attendance by employee', async () => {
+    const employeeId = Attendance[0].employee_id;
+    const expected = Attendance.filter(r => r.employee_id === employeeId);
+    await expect(service.findAll(employeeId)).resolves.toEqual(expected);
+  });
+
+  it('computes per-employee stats from the fixtures', async () => {
+    const employeeId = Attendance[0].employee_id;
+    const records = Attendance.filter(r => r.employee_id === employeeId);
+    const stats = await service.getStatsForEmployee(employeeId);
+    expect(stats.totalRecords).toBe(records.length);
+    expect(stats.daysPresent).toBe(records.filter(r => r.check_in != null).length);
+    expect(stats.totalHours).toBeGreaterThan(0);
+  });
+
+  it('returns empty stats for unknown employees', async () => {
+    const stats = await service.getStatsForEmployee('00000000-0000-4000-8000-000000000000');
+    expect(stats).toEqual({
+      totalRecords: 0,
+      totalHours: 0,
+      daysPresent: 0,
+      averageHours: 0,
+    });
+  });
+});

--- a/apps/api/src/attendance/attendance.service.ts
+++ b/apps/api/src/attendance/attendance.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import {
+  AttendanceLookup,
+  type AttendanceRecord,
+  type AttendanceStats,
+} from '@worksight/common';
+import { WorksightRepository } from '../db/worksight.repository';
+
+@Injectable()
+export class AttendanceService {
+  private readonly attendance = new AttendanceLookup();
+
+  constructor(private readonly repo: WorksightRepository) {}
+
+  async findAll(employeeId?: string): Promise<AttendanceRecord[]> {
+    if (this.repo.enabled) {
+      return this.repo.listAttendance(employeeId);
+    }
+    if (employeeId) {
+      return this.attendance.filter({ employee_id: employeeId }).all();
+    }
+    return this.attendance.all();
+  }
+
+  async getStatsForEmployee(employeeId: string): Promise<AttendanceStats> {
+    if (this.repo.enabled) {
+      return this.repo.getAttendanceStats(employeeId);
+    }
+    return this.attendance.getStats(employeeId);
+  }
+}

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -5,7 +5,7 @@
  *
  * Idempotent: truncates core tables then reloads. Requires 001_core.sql applied.
  */
-import { Activities, Assignments, Employees, Teams } from '@worksight/common';
+import { Activities, Assignments, Attendance, Employees, Teams } from '@worksight/common';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { Pool } from 'pg';
@@ -20,12 +20,14 @@ async function main() {
   const client = await pool.connect();
 
   try {
-    const schemaSql = readFileSync(join(__dirname, '..', '..', 'sql', '001_core.sql'), 'utf8');
-    await client.query(schemaSql);
+    for (const file of ['001_core.sql', '002_attendance.sql']) {
+      const schemaSql = readFileSync(join(__dirname, '..', '..', 'sql', file), 'utf8');
+      await client.query(schemaSql);
+    }
 
     await client.query('BEGIN');
     await client.query(
-      `TRUNCATE activities, assignments, teams, employees RESTART IDENTITY CASCADE`
+      `TRUNCATE attendance, activities, assignments, teams, employees RESTART IDENTITY CASCADE`
     );
 
     // Insert managers before reports so manager_id FKs resolve.
@@ -123,6 +125,23 @@ async function main() {
       );
     }
 
+    for (const record of Attendance) {
+      await client.query(
+        `INSERT INTO attendance
+           (system_id, employee_id, date, check_in, check_out, hours_worked, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+        [
+          record.system_id,
+          record.employee_id,
+          record.date,
+          record.check_in,
+          record.check_out,
+          record.hours_worked,
+          record.created_at,
+        ]
+      );
+    }
+
     await client.query('COMMIT');
 
     const counts = await client.query(
@@ -130,7 +149,8 @@ async function main() {
          (SELECT count(*)::int FROM employees) AS employees,
          (SELECT count(*)::int FROM teams) AS teams,
          (SELECT count(*)::int FROM assignments) AS assignments,
-         (SELECT count(*)::int FROM activities) AS activities`
+         (SELECT count(*)::int FROM activities) AS activities,
+         (SELECT count(*)::int FROM attendance) AS attendance`
     );
     console.log('Seeded', counts.rows[0]);
   } catch (error) {

--- a/apps/api/src/db/worksight.repository.ts
+++ b/apps/api/src/db/worksight.repository.ts
@@ -1,5 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import type { Activity, Assignment, EmployeeProfile, Team } from '@worksight/common';
+import type {
+  Activity,
+  Assignment,
+  AttendanceRecord,
+  AttendanceStats,
+  EmployeeProfile,
+  Team,
+} from '@worksight/common';
 import { DatabaseService } from './database.service';
 
 type EmployeeRow = {
@@ -42,6 +49,23 @@ type AssignmentRow = {
   priority: Assignment['priority'];
   created_at: Date;
   updated_at: Date;
+};
+
+type AttendanceRow = {
+  system_id: string;
+  employee_id: string;
+  date: Date;
+  check_in: Date | null;
+  check_out: Date | null;
+  // NUMERIC arrives as a string from node-postgres.
+  hours_worked: string | null;
+  created_at: Date;
+};
+
+type AttendanceStatsRow = {
+  total_records: number;
+  total_hours: number;
+  days_present: number;
 };
 
 type ActivityRow = {
@@ -122,6 +146,35 @@ export class WorksightRepository {
         );
     return rows.map(toActivity);
   }
+
+  async listAttendance(employeeId?: string): Promise<AttendanceRecord[]> {
+    const { rows } = employeeId
+      ? await this.db.query<AttendanceRow>(
+          `SELECT * FROM attendance WHERE employee_id = $1 ORDER BY date DESC`,
+          [employeeId]
+        )
+      : await this.db.query<AttendanceRow>(`SELECT * FROM attendance ORDER BY date DESC`);
+    return rows.map(toAttendance);
+  }
+
+  async getAttendanceStats(employeeId: string): Promise<AttendanceStats> {
+    const { rows } = await this.db.query<AttendanceStatsRow>(
+      `SELECT count(*)::int              AS total_records,
+              COALESCE(sum(hours_worked), 0)::float AS total_hours,
+              count(check_in)::int       AS days_present
+         FROM attendance
+        WHERE employee_id = $1`,
+      [employeeId]
+    );
+    const { total_records, total_hours, days_present } = rows[0];
+    const average = days_present > 0 ? total_hours / days_present : 0;
+    return {
+      totalRecords: total_records,
+      totalHours: Math.round(total_hours * 100) / 100,
+      daysPresent: days_present,
+      averageHours: Math.round(average * 100) / 100,
+    };
+  }
 }
 
 function toEmployee(row: EmployeeRow): EmployeeProfile {
@@ -169,6 +222,18 @@ function toAssignment(row: AssignmentRow): Assignment {
     priority: row.priority,
     created_at: new Date(row.created_at),
     updated_at: new Date(row.updated_at),
+  };
+}
+
+function toAttendance(row: AttendanceRow): AttendanceRecord {
+  return {
+    system_id: row.system_id,
+    employee_id: row.employee_id,
+    date: new Date(row.date),
+    check_in: row.check_in ? new Date(row.check_in) : null,
+    check_out: row.check_out ? new Date(row.check_out) : null,
+    hours_worked: row.hours_worked === null ? null : Number(row.hours_worked),
+    created_at: new Date(row.created_at),
   };
 }
 

--- a/docs/handoffs/2026-07-26-api-postgres.md
+++ b/docs/handoffs/2026-07-26-api-postgres.md
@@ -73,8 +73,24 @@ the same fixtures the offline demo uses.
 - `EmployeeProfile.manager_id` is nullable; `Assignment.employee_id` /
   `source_id` are UUIDs.
 
-Attendance / survey fixtures still contain invalid UUIDs — they are out of the
-API surface for now.
+Survey fixtures still contain invalid UUIDs — they are out of the API surface
+for now.
+
+## Attendance (follow-up branch `feat/api-attendance`)
+
+- Attendance fixtures repaired: 77 invalid `system_id`s regenerated as
+  deterministic UUIDs (`a77e0000-…`), and stale/placeholder `employee_id`s
+  (`0001`, `admin`, `guest`, old hex ids) remapped to the repaired employee
+  UUIDs using the per-block comments in the fixture file.
+  `AttendanceSchema.employee_id` is now `z.uuid()`.
+- `apps/api/sql/002_attendance.sql` — `attendance` table with an
+  `(employee_id, date)` unique constraint; seed script applies it and loads
+  the fixtures (77 rows on Neon).
+- New endpoints: `GET /attendance` (optional `?employee_id=`) and
+  `GET /attendance/stats/:employeeId`. DB mode computes stats with a SQL
+  aggregate; fixture mode uses `AttendanceLookup`, same rounding.
+- `GET /health` now reports the data source: `database` is `fixtures`,
+  `postgres`, or `unreachable` (with `status: degraded`).
 
 ## Related
 

--- a/packages/common/src/data/attendance.ts
+++ b/packages/common/src/data/attendance.ts
@@ -4,7 +4,7 @@ import { AttendanceRecord } from '../types';
 export const Attendance: AttendanceRecord[] = [
   // John Carlo Santos (E001) - Full week with overtime
   {
-    system_id: 'a1b2c3d4-e5f6-7890-abcd-123456789001',
+    system_id: 'a77e0000-0000-4000-8000-000000000001',
     employee_id: '08b6fc43-77e6-4fcf-8ed8-dafc16b4b025',
     date: new Date('2025-08-18'),
     check_in: new Date('2025-08-18T08:00:00+00:00'),
@@ -13,7 +13,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-18T08:00:00+00:00'),
   },
   {
-    system_id: 'a1b2c3d4-e5f6-7890-abcd-123456789002',
+    system_id: 'a77e0000-0000-4000-8000-000000000002',
     employee_id: '08b6fc43-77e6-4fcf-8ed8-dafc16b4b025',
     date: new Date('2025-08-19'),
     check_in: new Date('2025-08-19T08:15:00+00:00'),
@@ -22,7 +22,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-19T08:15:00+00:00'),
   },
   {
-    system_id: 'a1b2c3d4-e5f6-7890-abcd-123456789003',
+    system_id: 'a77e0000-0000-4000-8000-000000000003',
     employee_id: '08b6fc43-77e6-4fcf-8ed8-dafc16b4b025',
     date: new Date('2025-08-20'),
     check_in: new Date('2025-08-20T07:45:00+00:00'),
@@ -31,7 +31,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-20T07:45:00+00:00'),
   },
   {
-    system_id: 'a1b2c3d4-e5f6-7890-abcd-123456789004',
+    system_id: 'a77e0000-0000-4000-8000-000000000004',
     employee_id: '08b6fc43-77e6-4fcf-8ed8-dafc16b4b025',
     date: new Date('2025-08-21'),
     check_in: new Date('2025-08-21T08:30:00+00:00'),
@@ -40,7 +40,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-21T08:30:00+00:00'),
   },
   {
-    system_id: 'a1b2c3d4-e5f6-7890-abcd-123456789005',
+    system_id: 'a77e0000-0000-4000-8000-000000000005',
     employee_id: '08b6fc43-77e6-4fcf-8ed8-dafc16b4b025',
     date: new Date('2025-08-22'),
     check_in: new Date('2025-08-22T08:00:00+00:00'),
@@ -51,7 +51,7 @@ export const Attendance: AttendanceRecord[] = [
 
   // Adriel M. Magalona (E002) - Regular schedule with one late arrival
   {
-    system_id: 'b2c3d4e5-f6g7-8901-bcde-234567890001',
+    system_id: 'a77e0000-0000-4000-8000-000000000006',
     employee_id: '58f36d76-f382-41b4-ad3e-f8192958d12b',
     date: new Date('2025-08-18'),
     check_in: new Date('2025-08-18T09:00:00+00:00'),
@@ -60,7 +60,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-18T09:00:00+00:00'),
   },
   {
-    system_id: 'b2c3d4e5-f6g7-8901-bcde-234567890002',
+    system_id: 'a77e0000-0000-4000-8000-000000000007',
     employee_id: '58f36d76-f382-41b4-ad3e-f8192958d12b',
     date: new Date('2025-08-19'),
     check_in: new Date('2025-08-19T09:30:00+00:00'), // Late arrival
@@ -69,7 +69,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-19T09:30:00+00:00'),
   },
   {
-    system_id: 'b2c3d4e5-f6g7-8901-bcde-234567890003',
+    system_id: 'a77e0000-0000-4000-8000-000000000008',
     employee_id: '58f36d76-f382-41b4-ad3e-f8192958d12b',
     date: new Date('2025-08-20'),
     check_in: new Date('2025-08-20T08:45:00+00:00'),
@@ -78,7 +78,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-20T08:45:00+00:00'),
   },
   {
-    system_id: 'b2c3d4e5-f6g7-8901-bcde-234567890004',
+    system_id: 'a77e0000-0000-4000-8000-000000000009',
     employee_id: '58f36d76-f382-41b4-ad3e-f8192958d12b',
     date: new Date('2025-08-21'),
     check_in: new Date('2025-08-21T09:00:00+00:00'),
@@ -87,7 +87,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-21T09:00:00+00:00'),
   },
   {
-    system_id: 'b2c3d4e5-f6g7-8901-bcde-234567890005',
+    system_id: 'a77e0000-0000-4000-8000-000000000010',
     employee_id: '58f36d76-f382-41b4-ad3e-f8192958d12b',
     date: new Date('2025-08-22'),
     check_in: new Date('2025-08-22T08:50:00+00:00'),
@@ -98,7 +98,7 @@ export const Attendance: AttendanceRecord[] = [
 
   // Kiel Ethan L. Lanzanas (E003) - One day with early checkout (sick leave)
   {
-    system_id: 'c3d4e5f6-g7h8-9012-cdef-345678901001',
+    system_id: 'a77e0000-0000-4000-8000-000000000011',
     employee_id: '71400e28-3c2a-4694-8124-8fbb9a0b66d8',
     date: new Date('2025-08-18'),
     check_in: new Date('2025-08-18T08:30:00+00:00'),
@@ -107,7 +107,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-18T08:30:00+00:00'),
   },
   {
-    system_id: 'c3d4e5f6-g7h8-9012-cdef-345678901002',
+    system_id: 'a77e0000-0000-4000-8000-000000000012',
     employee_id: '71400e28-3c2a-4694-8124-8fbb9a0b66d8',
     date: new Date('2025-08-19'),
     check_in: new Date('2025-08-19T08:15:00+00:00'),
@@ -116,7 +116,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-19T08:15:00+00:00'),
   },
   {
-    system_id: 'c3d4e5f6-g7h8-9012-cdef-345678901003',
+    system_id: 'a77e0000-0000-4000-8000-000000000013',
     employee_id: '71400e28-3c2a-4694-8124-8fbb9a0b66d8',
     date: new Date('2025-08-20'),
     check_in: new Date('2025-08-20T08:20:00+00:00'),
@@ -125,7 +125,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-20T08:20:00+00:00'),
   },
   {
-    system_id: 'c3d4e5f6-g7h8-9012-cdef-345678901004',
+    system_id: 'a77e0000-0000-4000-8000-000000000014',
     employee_id: '71400e28-3c2a-4694-8124-8fbb9a0b66d8',
     date: new Date('2025-08-21'),
     check_in: new Date('2025-08-21T08:30:00+00:00'),
@@ -134,7 +134,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-21T08:30:00+00:00'),
   },
   {
-    system_id: 'c3d4e5f6-g7h8-9012-cdef-345678901005',
+    system_id: 'a77e0000-0000-4000-8000-000000000015',
     employee_id: '71400e28-3c2a-4694-8124-8fbb9a0b66d8',
     date: new Date('2025-08-22'),
     check_in: new Date('2025-08-22T08:10:00+00:00'),
@@ -145,7 +145,7 @@ export const Attendance: AttendanceRecord[] = [
 
   // Ellah D. Benerado (E004) - One day absent, consistent schedule otherwise
   {
-    system_id: 'd4e5f6g7-h8i9-0123-defg-456789012001',
+    system_id: 'a77e0000-0000-4000-8000-000000000016',
     employee_id: '88165ccb-2c80-455a-9ace-466a30448f67',
     date: new Date('2025-08-18'),
     check_in: new Date('2025-08-18T08:45:00+00:00'),
@@ -155,7 +155,7 @@ export const Attendance: AttendanceRecord[] = [
   },
   // August 19 - Absent (no record)
   {
-    system_id: 'd4e5f6g7-h8i9-0123-defg-456789012003',
+    system_id: 'a77e0000-0000-4000-8000-000000000017',
     employee_id: '88165ccb-2c80-455a-9ace-466a30448f67',
     date: new Date('2025-08-20'),
     check_in: new Date('2025-08-20T09:00:00+00:00'),
@@ -164,7 +164,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-20T09:00:00+00:00'),
   },
   {
-    system_id: 'd4e5f6g7-h8i9-0123-defg-456789012004',
+    system_id: 'a77e0000-0000-4000-8000-000000000018',
     employee_id: '88165ccb-2c80-455a-9ace-466a30448f67',
     date: new Date('2025-08-21'),
     check_in: new Date('2025-08-21T08:40:00+00:00'),
@@ -173,7 +173,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-21T08:40:00+00:00'),
   },
   {
-    system_id: 'd4e5f6g7-h8i9-0123-defg-456789012005',
+    system_id: 'a77e0000-0000-4000-8000-000000000019',
     employee_id: '88165ccb-2c80-455a-9ace-466a30448f67',
     date: new Date('2025-08-22'),
     check_in: new Date('2025-08-22T08:35:00+00:00'),
@@ -184,7 +184,7 @@ export const Attendance: AttendanceRecord[] = [
 
   // Current day (August 25) - Only check-ins, no check-outs yet
   {
-    system_id: 'e5f6g7h8-i9j0-1234-efgh-567890123001',
+    system_id: 'a77e0000-0000-4000-8000-000000000020',
     employee_id: '08b6fc43-77e6-4fcf-8ed8-dafc16b4b025',
     date: new Date('2025-08-25'),
     check_in: new Date('2025-08-25T08:05:00+00:00'),
@@ -193,7 +193,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-25T08:05:00+00:00'),
   },
   {
-    system_id: 'e5f6g7h8-i9j0-1234-efgh-567890123002',
+    system_id: 'a77e0000-0000-4000-8000-000000000021',
     employee_id: '58f36d76-f382-41b4-ad3e-f8192958d12b',
     date: new Date('2025-08-25'),
     check_in: new Date('2025-08-25T08:55:00+00:00'),
@@ -202,7 +202,7 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-25T08:55:00+00:00'),
   },
   {
-    system_id: 'e5f6g7h8-i9j0-1234-efgh-567890123003',
+    system_id: 'a77e0000-0000-4000-8000-000000000022',
     employee_id: '71400e28-3c2a-4694-8124-8fbb9a0b66d8',
     date: new Date('2025-08-25'),
     check_in: new Date('2025-08-25T08:25:00+00:00'),
@@ -213,8 +213,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // Mike Johnson – usually early, steady hours
   {
-    system_id: '9653df0b-b5a3-406f-b567-a83e90cf7ac3',
-    employee_id: '0001',
+    system_id: 'a77e0000-0000-4000-8000-000000000023',
+    employee_id: 'a1111111-1111-4111-8111-111111111101',
     date: new Date('2025-08-18'),
     check_in: new Date('2025-08-18T08:42:00+00:00'),
     check_out: new Date('2025-08-18T16:58:00+00:00'),
@@ -222,8 +222,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-18T08:42:00+00:00'),
   },
   {
-    system_id: '9b589624-474f-44bd-b147-51cf01fae2d0',
-    employee_id: '0001',
+    system_id: 'a77e0000-0000-4000-8000-000000000024',
+    employee_id: 'a1111111-1111-4111-8111-111111111101',
     date: new Date('2025-08-19'),
     check_in: new Date('2025-08-19T08:47:00+00:00'),
     check_out: new Date('2025-08-19T17:02:00+00:00'),
@@ -231,8 +231,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-19T08:47:00+00:00'),
   },
   {
-    system_id: '793727cf-da8b-41a5-adde-166d0785af76',
-    employee_id: '0001',
+    system_id: 'a77e0000-0000-4000-8000-000000000025',
+    employee_id: 'a1111111-1111-4111-8111-111111111101',
     date: new Date('2025-08-20'),
     check_in: new Date('2025-08-20T08:38:00+00:00'),
     check_out: new Date('2025-08-20T16:50:00+00:00'),
@@ -240,8 +240,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-20T08:38:00+00:00'),
   },
   {
-    system_id: '832f52d7-6a12-4266-a9e2-72ac0ec9b11c',
-    employee_id: '0001',
+    system_id: 'a77e0000-0000-4000-8000-000000000026',
+    employee_id: 'a1111111-1111-4111-8111-111111111101',
     date: new Date('2025-08-21'),
     check_in: new Date('2025-08-21T08:41:00+00:00'),
     check_out: new Date('2025-08-21T17:05:00+00:00'),
@@ -249,8 +249,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-21T08:41:00+00:00'),
   },
   {
-    system_id: '306436c9-d52d-4192-add4-9e0051ed3916',
-    employee_id: '0001',
+    system_id: 'a77e0000-0000-4000-8000-000000000027',
+    employee_id: 'a1111111-1111-4111-8111-111111111101',
     date: new Date('2025-08-22'),
     check_in: new Date('2025-08-22T08:36:00+00:00'),
     check_out: new Date('2025-08-22T16:55:00+00:00'),
@@ -260,8 +260,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // Sarah Wilson – tends to arrive right at 9, sometimes stays a bit later
   {
-    system_id: '2f692cff-37cb-4e46-914e-e4c9b72a688b',
-    employee_id: '0002',
+    system_id: 'a77e0000-0000-4000-8000-000000000028',
+    employee_id: 'a1111111-1111-4111-8111-111111111102',
     date: new Date('2025-08-18'),
     check_in: new Date('2025-08-18T09:02:00+00:00'),
     check_out: new Date('2025-08-18T17:15:00+00:00'),
@@ -269,8 +269,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-18T09:02:00+00:00'),
   },
   {
-    system_id: 'a31e0ef1-2da0-4372-be44-4cf5c2f69127',
-    employee_id: '0002',
+    system_id: 'a77e0000-0000-4000-8000-000000000029',
+    employee_id: 'a1111111-1111-4111-8111-111111111102',
     date: new Date('2025-08-19'),
     check_in: new Date('2025-08-19T08:57:00+00:00'),
     check_out: new Date('2025-08-19T17:20:00+00:00'),
@@ -278,8 +278,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-19T08:57:00+00:00'),
   },
   {
-    system_id: 'fc71386c-09a0-4b6e-baae-6fe2bb33bf9b',
-    employee_id: '0002',
+    system_id: 'a77e0000-0000-4000-8000-000000000030',
+    employee_id: 'a1111111-1111-4111-8111-111111111102',
     date: new Date('2025-08-20'),
     check_in: new Date('2025-08-20T09:08:00+00:00'),
     check_out: new Date('2025-08-20T17:25:00+00:00'),
@@ -287,8 +287,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-20T09:08:00+00:00'),
   },
   {
-    system_id: 'a7d5f306-2105-4173-82f7-67bfc1c89316',
-    employee_id: '0002',
+    system_id: 'a77e0000-0000-4000-8000-000000000031',
+    employee_id: 'a1111111-1111-4111-8111-111111111102',
     date: new Date('2025-08-21'),
     check_in: new Date('2025-08-21T09:05:00+00:00'),
     check_out: new Date('2025-08-21T17:10:00+00:00'),
@@ -296,8 +296,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-21T09:05:00+00:00'),
   },
   {
-    system_id: '861bf1b6-1119-4a22-b074-2d7ac54b767a',
-    employee_id: '0002',
+    system_id: 'a77e0000-0000-4000-8000-000000000032',
+    employee_id: 'a1111111-1111-4111-8111-111111111102',
     date: new Date('2025-08-22'),
     check_in: new Date('2025-08-22T09:00:00+00:00'),
     check_out: new Date('2025-08-22T17:18:00+00:00'),
@@ -307,8 +307,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // Alex Chen – slightly inconsistent, sometimes later
   {
-    system_id: '3c2a3941-2e7a-4519-b235-5f9f4b961aca',
-    employee_id: '0003',
+    system_id: 'a77e0000-0000-4000-8000-000000000033',
+    employee_id: 'a1111111-1111-4111-8111-111111111104',
     date: new Date('2025-08-18'),
     check_in: new Date('2025-08-18T09:12:00+00:00'),
     check_out: new Date('2025-08-18T17:22:00+00:00'),
@@ -316,8 +316,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-18T09:12:00+00:00'),
   },
   {
-    system_id: '18c23b5b-a7ab-4359-9242-a0ab15fd970c',
-    employee_id: '0003',
+    system_id: 'a77e0000-0000-4000-8000-000000000034',
+    employee_id: 'a1111111-1111-4111-8111-111111111104',
     date: new Date('2025-08-19'),
     check_in: new Date('2025-08-19T09:05:00+00:00'),
     check_out: new Date('2025-08-19T17:15:00+00:00'),
@@ -325,8 +325,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-19T09:05:00+00:00'),
   },
   {
-    system_id: '0155d9c0-d147-47fb-a990-4a885da166b8',
-    employee_id: '0003',
+    system_id: 'a77e0000-0000-4000-8000-000000000035',
+    employee_id: 'a1111111-1111-4111-8111-111111111104',
     date: new Date('2025-08-20'),
     check_in: new Date('2025-08-20T09:20:00+00:00'),
     check_out: new Date('2025-08-20T17:28:00+00:00'),
@@ -334,8 +334,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-20T09:20:00+00:00'),
   },
   {
-    system_id: '1fd1f36d-f595-427b-bbc7-9b04f6b73b1a',
-    employee_id: '0003',
+    system_id: 'a77e0000-0000-4000-8000-000000000036',
+    employee_id: 'a1111111-1111-4111-8111-111111111104',
     date: new Date('2025-08-21'),
     check_in: new Date('2025-08-21T08:55:00+00:00'),
     check_out: new Date('2025-08-21T17:05:00+00:00'),
@@ -343,8 +343,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-21T08:55:00+00:00'),
   },
   {
-    system_id: '4ee80f9d-9846-4ca7-b2f5-862bec816362',
-    employee_id: '0003',
+    system_id: 'a77e0000-0000-4000-8000-000000000037',
+    employee_id: 'a1111111-1111-4111-8111-111111111104',
     date: new Date('2025-08-22'),
     check_in: new Date('2025-08-22T09:18:00+00:00'),
     check_out: new Date('2025-08-22T17:35:00+00:00'),
@@ -354,8 +354,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // System Admin – clockwork consistent
   {
-    system_id: '9f0b0985-5127-4054-830c-2319e2758892',
-    employee_id: 'admin',
+    system_id: 'a77e0000-0000-4000-8000-000000000038',
+    employee_id: '7f1fcc2a-4025-49e3-9090-bf0ff9fee898',
     date: new Date('2025-08-18'),
     check_in: new Date('2025-08-18T08:30:00+00:00'),
     check_out: new Date('2025-08-18T16:30:00+00:00'),
@@ -363,8 +363,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-18T08:30:00+00:00'),
   },
   {
-    system_id: '810bfc65-a422-43f0-a612-650fceca9891',
-    employee_id: 'admin',
+    system_id: 'a77e0000-0000-4000-8000-000000000039',
+    employee_id: '7f1fcc2a-4025-49e3-9090-bf0ff9fee898',
     date: new Date('2025-08-19'),
     check_in: new Date('2025-08-19T08:30:00+00:00'),
     check_out: new Date('2025-08-19T16:30:00+00:00'),
@@ -372,8 +372,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-19T08:30:00+00:00'),
   },
   {
-    system_id: '6582760e-3227-4275-9dcd-6edc750e16ac',
-    employee_id: 'admin',
+    system_id: 'a77e0000-0000-4000-8000-000000000040',
+    employee_id: '7f1fcc2a-4025-49e3-9090-bf0ff9fee898',
     date: new Date('2025-08-20'),
     check_in: new Date('2025-08-20T08:31:00+00:00'),
     check_out: new Date('2025-08-20T16:31:00+00:00'),
@@ -381,8 +381,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-20T08:31:00+00:00'),
   },
   {
-    system_id: 'a082990b-a5de-4395-9b88-fc81e106de6b',
-    employee_id: 'admin',
+    system_id: 'a77e0000-0000-4000-8000-000000000041',
+    employee_id: '7f1fcc2a-4025-49e3-9090-bf0ff9fee898',
     date: new Date('2025-08-21'),
     check_in: new Date('2025-08-21T08:29:00+00:00'),
     check_out: new Date('2025-08-21T16:29:00+00:00'),
@@ -390,8 +390,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-21T08:29:00+00:00'),
   },
   {
-    system_id: '20a4077e-6d5a-4c04-afe8-836ca3c64522',
-    employee_id: 'admin',
+    system_id: 'a77e0000-0000-4000-8000-000000000042',
+    employee_id: '7f1fcc2a-4025-49e3-9090-bf0ff9fee898',
     date: new Date('2025-08-22'),
     check_in: new Date('2025-08-22T08:32:00+00:00'),
     check_out: new Date('2025-08-22T16:32:00+00:00'),
@@ -401,8 +401,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // System Guest – short shifts, scattered
   {
-    system_id: '13c4e8d2-9403-4b41-8ee6-d34526a19d76',
-    employee_id: 'guest',
+    system_id: 'a77e0000-0000-4000-8000-000000000043',
+    employee_id: 'f52281b2-064e-4ee7-b4bb-6327fe1f74f7',
     date: new Date('2025-08-18'),
     check_in: new Date('2025-08-18T09:30:00+00:00'),
     check_out: new Date('2025-08-18T12:00:00+00:00'),
@@ -410,8 +410,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-18T09:30:00+00:00'),
   },
   {
-    system_id: 'df99fe51-7650-4108-aab2-40e79eb09e0a',
-    employee_id: 'guest',
+    system_id: 'a77e0000-0000-4000-8000-000000000044',
+    employee_id: 'f52281b2-064e-4ee7-b4bb-6327fe1f74f7',
     date: new Date('2025-08-19'),
     check_in: new Date('2025-08-19T14:00:00+00:00'),
     check_out: new Date('2025-08-19T17:00:00+00:00'),
@@ -419,8 +419,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-19T14:00:00+00:00'),
   },
   {
-    system_id: 'e6453772-06b2-47b1-ad24-7864368cd9fc',
-    employee_id: 'guest',
+    system_id: 'a77e0000-0000-4000-8000-000000000045',
+    employee_id: 'f52281b2-064e-4ee7-b4bb-6327fe1f74f7',
     date: new Date('2025-08-20'),
     check_in: new Date('2025-08-20T10:15:00+00:00'),
     check_out: new Date('2025-08-20T13:00:00+00:00'),
@@ -428,8 +428,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-20T10:15:00+00:00'),
   },
   {
-    system_id: '021ad691-49d5-49e2-8a3c-dfb819fa96a1',
-    employee_id: 'guest',
+    system_id: 'a77e0000-0000-4000-8000-000000000046',
+    employee_id: 'f52281b2-064e-4ee7-b4bb-6327fe1f74f7',
     date: new Date('2025-08-21'),
     check_in: new Date('2025-08-21T08:00:00+00:00'),
     check_out: new Date('2025-08-21T11:00:00+00:00'),
@@ -437,8 +437,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-21T08:00:00+00:00'),
   },
   {
-    system_id: '5357a459-2bf3-4e21-8d9a-943c03c3a2c5',
-    employee_id: 'guest',
+    system_id: 'a77e0000-0000-4000-8000-000000000047',
+    employee_id: 'f52281b2-064e-4ee7-b4bb-6327fe1f74f7',
     date: new Date('2025-08-22'),
     check_in: new Date('2025-08-22T15:00:00+00:00'),
     check_out: new Date('2025-08-22T18:00:00+00:00'),
@@ -448,8 +448,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // System Employee – normal 8h worker
   {
-    system_id: 'c2249fc9-b9bd-4055-8aca-09934e4c610d',
-    employee_id: 'employee',
+    system_id: 'a77e0000-0000-4000-8000-000000000048',
+    employee_id: '077788f9-e8a7-4cc9-b7e0-5e4610a56a39',
     date: new Date('2025-08-18'),
     check_in: new Date('2025-08-18T08:55:00+00:00'),
     check_out: new Date('2025-08-18T17:05:00+00:00'),
@@ -457,8 +457,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-18T08:55:00+00:00'),
   },
   {
-    system_id: 'f7115d3e-57c5-432d-b31c-44c360f4dccf',
-    employee_id: 'employee',
+    system_id: 'a77e0000-0000-4000-8000-000000000049',
+    employee_id: '077788f9-e8a7-4cc9-b7e0-5e4610a56a39',
     date: new Date('2025-08-19'),
     check_in: new Date('2025-08-19T08:50:00+00:00'),
     check_out: new Date('2025-08-19T17:02:00+00:00'),
@@ -466,8 +466,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-19T08:50:00+00:00'),
   },
   {
-    system_id: '7747a83b-d3dd-49c5-b049-edc99213ee71',
-    employee_id: 'employee',
+    system_id: 'a77e0000-0000-4000-8000-000000000050',
+    employee_id: '077788f9-e8a7-4cc9-b7e0-5e4610a56a39',
     date: new Date('2025-08-20'),
     check_in: new Date('2025-08-20T09:01:00+00:00'),
     check_out: new Date('2025-08-20T17:12:00+00:00'),
@@ -475,8 +475,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-20T09:01:00+00:00'),
   },
   {
-    system_id: '37fb8762-efe6-459f-a614-02f2ce9924e7',
-    employee_id: 'employee',
+    system_id: 'a77e0000-0000-4000-8000-000000000051',
+    employee_id: '077788f9-e8a7-4cc9-b7e0-5e4610a56a39',
     date: new Date('2025-08-21'),
     check_in: new Date('2025-08-21T08:42:00+00:00'),
     check_out: new Date('2025-08-21T16:57:00+00:00'),
@@ -484,8 +484,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-08-21T08:42:00+00:00'),
   },
   {
-    system_id: 'e240eb42-899d-4b80-9287-35af82eec437',
-    employee_id: 'employee',
+    system_id: 'a77e0000-0000-4000-8000-000000000052',
+    employee_id: '077788f9-e8a7-4cc9-b7e0-5e4610a56a39',
     date: new Date('2025-08-22'),
     check_in: new Date('2025-08-22T08:47:00+00:00'),
     check_out: new Date('2025-08-22T17:06:00+00:00'),
@@ -495,8 +495,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // Jane Doe - Infra
   {
-    system_id: 'a1b2c3d4-e5f6-7890-abcd-111111111111',
-    employee_id: 'f2b6f6a7-3d9e-4f91-92b1-1f12345abcde',
+    system_id: 'a77e0000-0000-4000-8000-000000000053',
+    employee_id: 'a1111111-1111-4111-8111-111111111103',
     date: new Date('2025-09-01'),
     check_in: new Date('2025-09-01T08:55:00+00:00'),
     check_out: new Date('2025-09-01T17:10:00+00:00'),
@@ -504,8 +504,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-01T08:55:00+00:00'),
   },
   {
-    system_id: 'a1b2c3d4-e5f6-7890-abcd-111111111112',
-    employee_id: 'f2b6f6a7-3d9e-4f91-92b1-1f12345abcde',
+    system_id: 'a77e0000-0000-4000-8000-000000000054',
+    employee_id: 'a1111111-1111-4111-8111-111111111103',
     date: new Date('2025-09-02'),
     check_in: new Date('2025-09-02T09:05:00+00:00'),
     check_out: new Date('2025-09-02T17:00:00+00:00'),
@@ -513,8 +513,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-02T09:05:00+00:00'),
   },
   {
-    system_id: 'a1b2c3d4-e5f6-7890-abcd-111111111113',
-    employee_id: 'f2b6f6a7-3d9e-4f91-92b1-1f12345abcde',
+    system_id: 'a77e0000-0000-4000-8000-000000000055',
+    employee_id: 'a1111111-1111-4111-8111-111111111103',
     date: new Date('2025-09-03'),
     check_in: new Date('2025-09-03T08:45:00+00:00'),
     check_out: new Date('2025-09-03T17:05:00+00:00'),
@@ -522,8 +522,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-03T08:45:00+00:00'),
   },
   {
-    system_id: 'a1b2c3d4-e5f6-7890-abcd-111111111114',
-    employee_id: 'f2b6f6a7-3d9e-4f91-92b1-1f12345abcde',
+    system_id: 'a77e0000-0000-4000-8000-000000000056',
+    employee_id: 'a1111111-1111-4111-8111-111111111103',
     date: new Date('2025-09-04'),
     check_in: new Date('2025-09-04T09:00:00+00:00'),
     check_out: new Date('2025-09-04T16:50:00+00:00'),
@@ -531,8 +531,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-04T09:00:00+00:00'),
   },
   {
-    system_id: 'a1b2c3d4-e5f6-7890-abcd-111111111115',
-    employee_id: 'f2b6f6a7-3d9e-4f91-92b1-1f12345abcde',
+    system_id: 'a77e0000-0000-4000-8000-000000000057',
+    employee_id: 'a1111111-1111-4111-8111-111111111103',
     date: new Date('2025-09-05'),
     check_in: new Date('2025-09-05T08:50:00+00:00'),
     check_out: new Date('2025-09-05T17:20:00+00:00'),
@@ -542,8 +542,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // Robert Taylor - Engineering
   {
-    system_id: 'b1b2c3d4-e5f6-7890-abcd-222222222221',
-    employee_id: 'a9c2d7e1-2b34-4b56-bcd7-98f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000058',
+    employee_id: 'a1111111-1111-4111-8111-111111111105',
     date: new Date('2025-09-02'),
     check_in: new Date('2025-09-02T09:10:00+00:00'),
     check_out: new Date('2025-09-02T17:15:00+00:00'),
@@ -551,8 +551,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-02T09:10:00+00:00'),
   },
   {
-    system_id: 'b1b2c3d4-e5f6-7890-abcd-222222222222',
-    employee_id: 'a9c2d7e1-2b34-4b56-bcd7-98f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000059',
+    employee_id: 'a1111111-1111-4111-8111-111111111105',
     date: new Date('2025-09-03'),
     check_in: new Date('2025-09-03T08:55:00+00:00'),
     check_out: new Date('2025-09-03T17:00:00+00:00'),
@@ -560,8 +560,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-03T08:55:00+00:00'),
   },
   {
-    system_id: 'b1b2c3d4-e5f6-7890-abcd-222222222223',
-    employee_id: 'a9c2d7e1-2b34-4b56-bcd7-98f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000060',
+    employee_id: 'a1111111-1111-4111-8111-111111111105',
     date: new Date('2025-09-04'),
     check_in: new Date('2025-09-04T08:40:00+00:00'),
     check_out: new Date('2025-09-04T17:05:00+00:00'),
@@ -569,8 +569,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-04T08:40:00+00:00'),
   },
   {
-    system_id: 'b1b2c3d4-e5f6-7890-abcd-222222222224',
-    employee_id: 'a9c2d7e1-2b34-4b56-bcd7-98f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000061',
+    employee_id: 'a1111111-1111-4111-8111-111111111105',
     date: new Date('2025-09-05'),
     check_in: new Date('2025-09-05T09:05:00+00:00'),
     check_out: new Date('2025-09-05T17:00:00+00:00'),
@@ -578,8 +578,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-05T09:05:00+00:00'),
   },
   {
-    system_id: 'b1b2c3d4-e5f6-7890-abcd-222222222225',
-    employee_id: 'a9c2d7e1-2b34-4b56-bcd7-98f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000062',
+    employee_id: 'a1111111-1111-4111-8111-111111111105',
     date: new Date('2025-09-08'),
     check_in: new Date('2025-09-08T08:50:00+00:00'),
     check_out: new Date('2025-09-08T17:25:00+00:00'),
@@ -589,8 +589,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // Lisa Garcia - Data
   {
-    system_id: 'c1b2c3d4-e5f6-7890-abcd-333333333331',
-    employee_id: 'b8f9c7d6-1e23-4f12-8bcd-67e12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000063',
+    employee_id: 'a1111111-1111-4111-8111-111111111106',
     date: new Date('2025-09-02'),
     check_in: new Date('2025-09-02T09:15:00+00:00'),
     check_out: new Date('2025-09-02T17:05:00+00:00'),
@@ -598,8 +598,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-02T09:15:00+00:00'),
   },
   {
-    system_id: 'c1b2c3d4-e5f6-7890-abcd-333333333332',
-    employee_id: 'b8f9c7d6-1e23-4f12-8bcd-67e12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000064',
+    employee_id: 'a1111111-1111-4111-8111-111111111106',
     date: new Date('2025-09-03'),
     check_in: new Date('2025-09-03T08:50:00+00:00'),
     check_out: new Date('2025-09-03T17:10:00+00:00'),
@@ -607,8 +607,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-03T08:50:00+00:00'),
   },
   {
-    system_id: 'c1b2c3d4-e5f6-7890-abcd-333333333333',
-    employee_id: 'b8f9c7d6-1e23-4f12-8bcd-67e12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000065',
+    employee_id: 'a1111111-1111-4111-8111-111111111106',
     date: new Date('2025-09-04'),
     check_in: new Date('2025-09-04T08:55:00+00:00'),
     check_out: new Date('2025-09-04T17:00:00+00:00'),
@@ -616,8 +616,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-04T08:55:00+00:00'),
   },
   {
-    system_id: 'c1b2c3d4-e5f6-7890-abcd-333333333334',
-    employee_id: 'b8f9c7d6-1e23-4f12-8bcd-67e12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000066',
+    employee_id: 'a1111111-1111-4111-8111-111111111106',
     date: new Date('2025-09-05'),
     check_in: new Date('2025-09-05T09:00:00+00:00'),
     check_out: new Date('2025-09-05T16:55:00+00:00'),
@@ -625,8 +625,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-05T09:00:00+00:00'),
   },
   {
-    system_id: 'c1b2c3d4-e5f6-7890-abcd-333333333335',
-    employee_id: 'b8f9c7d6-1e23-4f12-8bcd-67e12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000067',
+    employee_id: 'a1111111-1111-4111-8111-111111111106',
     date: new Date('2025-09-08'),
     check_in: new Date('2025-09-08T08:45:00+00:00'),
     check_out: new Date('2025-09-08T17:20:00+00:00'),
@@ -636,8 +636,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // David Brown - Data
   {
-    system_id: 'd1b2c3d4-e5f6-7890-abcd-444444444441',
-    employee_id: 'c7e8d9f1-4a56-4b78-bdef-45f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000068',
+    employee_id: 'a1111111-1111-4111-8111-111111111107',
     date: new Date('2025-09-03'),
     check_in: new Date('2025-09-03T08:55:00+00:00'),
     check_out: new Date('2025-09-03T17:00:00+00:00'),
@@ -645,8 +645,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-03T08:55:00+00:00'),
   },
   {
-    system_id: 'd1b2c3d4-e5f6-7890-abcd-444444444442',
-    employee_id: 'c7e8d9f1-4a56-4b78-bdef-45f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000069',
+    employee_id: 'a1111111-1111-4111-8111-111111111107',
     date: new Date('2025-09-04'),
     check_in: new Date('2025-09-04T09:05:00+00:00'),
     check_out: new Date('2025-09-04T16:50:00+00:00'),
@@ -654,8 +654,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-04T09:05:00+00:00'),
   },
   {
-    system_id: 'd1b2c3d4-e5f6-7890-abcd-444444444443',
-    employee_id: 'c7e8d9f1-4a56-4b78-bdef-45f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000070',
+    employee_id: 'a1111111-1111-4111-8111-111111111107',
     date: new Date('2025-09-05'),
     check_in: new Date('2025-09-05T08:50:00+00:00'),
     check_out: new Date('2025-09-05T17:05:00+00:00'),
@@ -663,8 +663,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-05T08:50:00+00:00'),
   },
   {
-    system_id: 'd1b2c3d4-e5f6-7890-abcd-444444444444',
-    employee_id: 'c7e8d9f1-4a56-4b78-bdef-45f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000071',
+    employee_id: 'a1111111-1111-4111-8111-111111111107',
     date: new Date('2025-09-08'),
     check_in: new Date('2025-09-08T09:00:00+00:00'),
     check_out: new Date('2025-09-08T17:10:00+00:00'),
@@ -672,8 +672,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-08T09:00:00+00:00'),
   },
   {
-    system_id: 'd1b2c3d4-e5f6-7890-abcd-444444444445',
-    employee_id: 'c7e8d9f1-4a56-4b78-bdef-45f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000072',
+    employee_id: 'a1111111-1111-4111-8111-111111111107',
     date: new Date('2025-09-09'),
     check_in: new Date('2025-09-09T08:40:00+00:00'),
     check_out: new Date('2025-09-09T17:20:00+00:00'),
@@ -683,8 +683,8 @@ export const Attendance: AttendanceRecord[] = [
 
   // Maria Lopez - Engineering
   {
-    system_id: 'e1b2c3d4-e5f6-7890-abcd-555555555551',
-    employee_id: 'd5f4a2b1-6c78-4d91-a123-12f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000073',
+    employee_id: 'a1111111-1111-4111-8111-111111111108',
     date: new Date('2025-09-04'),
     check_in: new Date('2025-09-04T08:55:00+00:00'),
     check_out: new Date('2025-09-04T17:00:00+00:00'),
@@ -692,8 +692,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-04T08:55:00+00:00'),
   },
   {
-    system_id: 'e1b2c3d4-e5f6-7890-abcd-555555555552',
-    employee_id: 'd5f4a2b1-6c78-4d91-a123-12f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000074',
+    employee_id: 'a1111111-1111-4111-8111-111111111108',
     date: new Date('2025-09-05'),
     check_in: new Date('2025-09-05T09:05:00+00:00'),
     check_out: new Date('2025-09-05T17:15:00+00:00'),
@@ -701,8 +701,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-05T09:05:00+00:00'),
   },
   {
-    system_id: 'e1b2c3d4-e5f6-7890-abcd-555555555553',
-    employee_id: 'd5f4a2b1-6c78-4d91-a123-12f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000075',
+    employee_id: 'a1111111-1111-4111-8111-111111111108',
     date: new Date('2025-09-08'),
     check_in: new Date('2025-09-08T08:45:00+00:00'),
     check_out: new Date('2025-09-08T17:20:00+00:00'),
@@ -710,8 +710,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-08T08:45:00+00:00'),
   },
   {
-    system_id: 'e1b2c3d4-e5f6-7890-abcd-555555555554',
-    employee_id: 'd5f4a2b1-6c78-4d91-a123-12f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000076',
+    employee_id: 'a1111111-1111-4111-8111-111111111108',
     date: new Date('2025-09-09'),
     check_in: new Date('2025-09-09T09:00:00+00:00'),
     check_out: new Date('2025-09-09T16:55:00+00:00'),
@@ -719,8 +719,8 @@ export const Attendance: AttendanceRecord[] = [
     created_at: new Date('2025-09-09T09:00:00+00:00'),
   },
   {
-    system_id: 'e1b2c3d4-e5f6-7890-abcd-555555555555',
-    employee_id: 'd5f4a2b1-6c78-4d91-a123-12f12345abcd',
+    system_id: 'a77e0000-0000-4000-8000-000000000077',
+    employee_id: 'a1111111-1111-4111-8111-111111111108',
     date: new Date('2025-09-10'),
     check_in: new Date('2025-09-10T08:50:00+00:00'),
     check_out: new Date('2025-09-10T17:05:00+00:00'),

--- a/packages/common/src/types/attendance.ts
+++ b/packages/common/src/types/attendance.ts
@@ -10,7 +10,7 @@ export const AttendanceSchema = z.object({
   system_id: z.uuid(),
 
   /** Unique identifier of the employee */
-  employee_id: z.string(),
+  employee_id: z.uuid(),
 
   /** Date of the attendance */
   date: z.date(),


### PR DESCRIPTION
Stacked on #28.

## Summary

- Repairs the attendance fixtures (last dataset with invalid UUIDs in the API surface): 77 `system_id`s regenerated as deterministic UUIDs, placeholder/stale `employee_id`s (`0001`, `admin`, `guest`, old hex ids) remapped to real employees via the per-block fixture comments. `AttendanceSchema.employee_id` is now `z.uuid()`; every record verified to reference an existing employee, no duplicate `(employee_id, date)` pairs.
- `apps/api/sql/002_attendance.sql` + seed extension — 77 rows seeded on Neon.
- `GET /attendance` (optional `?employee_id=`) and `GET /attendance/stats/:employeeId`, DB-backed with fixture fallback like users/tasks. Stats use a SQL aggregate in DB mode, `AttendanceLookup` otherwise (same rounding).
- `GET /health` now pings the pool and reports `database: fixtures | postgres | unreachable`.

## Test plan

- [x] `pnpm --filter @worksight/api type-check` / `lint` / `test` — 14 tests green (4 new)
- [x] Reseeded Neon via direct URL: 77 attendance rows
- [x] Booted dist against the Neon pooler: `/health` → `postgres`, `/attendance` → 77, stats for E001 → 6 records / 46.5h

Made with [Cursor](https://cursor.com)