### PR TITLE
feat(api): DB-backed /users/stats and /tasks/stats

### DIFF
--- a/apps/api/src/tasks/tasks.service.spec.ts
+++ b/apps/api/src/tasks/tasks.service.spec.ts
@@ -25,10 +25,10 @@ describe('TasksService', () => {
     await expect(service.findById('does-not-exist')).resolves.toBeNull();
   });
 
-  it('computes per-employee stats from the fixtures', () => {
+  it('computes per-employee stats from the fixtures', async () => {
     const employeeId = Assignments[0].employee_id;
     const expectedTotal = Assignments.filter(a => a.employee_id === employeeId).length;
-    const stats = service.getStatsForEmployee(employeeId);
+    const stats = await service.getStatsForEmployee(employeeId);
     expect(stats.totalTasks).toBe(expectedTotal);
     expect(stats.completionRate).toBeGreaterThanOrEqual(0);
   });

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -26,7 +26,15 @@ export class TasksService {
     return this.assignments.filter({ id }).first();
   }
 
-  getStatsForEmployee(employeeId: string): ReturnType<AssignmentLookup['getStats']> {
+  async getStatsForEmployee(employeeId: string): Promise<ReturnType<AssignmentLookup['getStats']>> {
+    if (this.repo.enabled) {
+      // Same lookup math, hydrated from Postgres instead of the fixtures.
+      const [assignments, activities] = await Promise.all([
+        this.repo.listAssignments(employeeId),
+        this.repo.listActivities(employeeId),
+      ]);
+      return new AssignmentLookup(assignments).getStats(employeeId, activities);
+    }
     return this.assignments.getStats(employeeId);
   }
 

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -24,8 +24,8 @@ describe('UsersService', () => {
     await expect(service.findById('does-not-exist')).resolves.toBeNull();
   });
 
-  it('computes stats over the shared fixtures', () => {
-    const stats = service.getStats();
+  it('computes stats over the shared fixtures', async () => {
+    const stats = await service.getStats();
     expect(stats.totalEmployees).toBe(Employees.length);
     const employeeRole = stats.roles.find(r => r.role === 'employee');
     expect(employeeRole?.count).toBe(Employees.filter(e => e.role === 'employee').length);

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -23,9 +23,11 @@ export class UsersService {
     return this.employees.getById(id);
   }
 
-  getStats(): ReturnType<EmployeeLookup['getStats']> {
-    // Stats still come from the in-memory lookup util; Postgres path returns the
-    // same shape over the loaded fixture until a SQL aggregate lands.
+  async getStats(): Promise<ReturnType<EmployeeLookup['getStats']>> {
+    if (this.repo.enabled) {
+      // Same lookup math, hydrated from Postgres instead of the fixtures.
+      return new EmployeeLookup(await this.repo.listEmployees()).getStats();
+    }
     return this.employees.getStats();
   }
 

--- a/docs/handoffs/2026-07-26-api-postgres.md
+++ b/docs/handoffs/2026-07-26-api-postgres.md
@@ -73,6 +73,14 @@ the same fixtures the offline demo uses.
 - `EmployeeProfile.manager_id` is nullable; `Assignment.employee_id` /
   `source_id` are UUIDs.
 
+## DB-backed stats (follow-up branch `feat/api-db-stats`)
+
+- `GET /users/stats` and `GET /tasks/stats/:employeeId` now hydrate the
+  `@worksight/common` lookup helpers from Postgres in DB mode, so stats
+  reflect live rows instead of always echoing fixtures.
+  `AssignmentLookup.getStats` gained an optional `activities` parameter
+  (defaults to the fixture set, so web callers are unaffected).
+
 ## Surveys (follow-up branch `feat/api-surveys`)
 
 - Survey fixtures repaired: `SURVEY-123` → the real survey UUID, `EMP-001` →

--- a/packages/common/src/utils/tasks.ts
+++ b/packages/common/src/utils/tasks.ts
@@ -48,8 +48,11 @@ export class AssignmentLookup extends BaseLookup<typeof AssignmentSchema> {
     return this.filter({ employee_id, ...filters });
   }
 
-  /** Compute stats for a given employee across tasks and activities */
-  getStats(employee_id: string) {
+  /**
+   * Compute stats for a given employee across tasks and activities.
+   * @param activities activity set to aggregate; defaults to the fixture data
+   */
+  getStats(employee_id: string, activities: Activity[] = Activities) {
     const employeeAssignments = this.filter({ employee_id });
     const completedAssignments = employeeAssignments.filter({ status: 'completed' });
 
@@ -57,7 +60,7 @@ export class AssignmentLookup extends BaseLookup<typeof AssignmentSchema> {
     const completedStoryPoints = completedAssignments.all().reduce((sum, t) => sum + (t.points ?? 0), 0);
 
     // Activities stats
-    const employeeActivities = Activities.filter((a) => a.employee_id === employee_id);
+    const employeeActivities = activities.filter((a) => a.employee_id === employee_id);
     const afterHours = employeeActivities.filter((a) => a.is_after_hours).length;
     const weekend = employeeActivities.filter((a) => a.is_weekend).length;
     const urgent = employeeActivities.filter((a) => a.is_urgent).length;


### PR DESCRIPTION
Stacked on #30.

## Summary

- `GET /users/stats` and `GET /tasks/stats/:employeeId` always computed from fixtures, so in DB mode they disagreed with the list endpoints they summarize. They now hydrate the `@worksight/common` lookup helpers from Postgres rows — same aggregation math, live data.
- Fixes a latent bug in `AssignmentLookup.getStats`: it hardcoded the fixture `Activities` import even when the lookup was constructed with custom entries. The activity set is now an optional parameter defaulting to the fixtures, so web callers are unaffected (`@worksight/web` type-check verified).

## Test plan

- [x] `pnpm --filter @worksight/api type-check` / `lint` / `test` — 19 green
- [x] `pnpm --filter @worksight/web type-check` — green (signature change is backwards compatible)
- [x] Against the Neon pooler: `/users/stats` reports 15 employees by role/department; `/tasks/stats/E001-uuid` reports 4 tasks, 50% completion, 6 activities

Made with [Cursor](https://cursor.com)