### PR TITLE
feat(api): optional Neon/Postgres via Drizzle (fixture fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,18 @@ pnpm --filter @worksight/docs build
 
 ## MVP data layer
 
-- **Web:** dashboard / admin / tasks views consume `@worksight/common` fixtures
-  (via a thin bridge such as `apps/web/src/lib/mvp-data.ts` on the wire-web
-  branch).
-- **API:** Nest endpoints return the same fixture shapes (`EmployeeProfile`,
-  `Team`, `Assignment`, `Activity`). There is **no** DB/Supabase read path for
-  those endpoints yet.
-- Fixture-backed routes (API): `GET /users`, `/users/:id`, `/users/stats`,
+- **Default:** dashboard / admin / Nest list endpoints use `@worksight/common`
+  fixtures (no DB required).
+- **Optional Postgres/Neon:** set `DATABASE_URL` on the API. Schema + seed live
+  under `apps/api` (Drizzle). Local: `docker compose up -d postgres`, then
+  `pnpm --filter @worksight/api db:push` and `db:seed`. See
+  `apps/api/.env.example`.
+- **Web:** can still call Nest (`NEXT_PUBLIC_USE_API=true`) whether Nest is on
+  fixtures or Postgres — response shapes stay the same.
+- Fixture/DB-backed routes (API): `GET /users`, `/users/:id`, `/users/stats`,
   `/teams`, `/teams/:id`, `/tasks`, `/tasks/:id`, `/tasks/stats/:employeeId`,
-  `/activities`, plus `/`, `/ping`, `/health`.
+  `/activities`, plus `/`, `/ping`, `/health` (`dataBackend`: `fixtures` |
+  `postgres`).
 
 ## Deployment
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,9 @@
+# Copy to .env (or export) for Neon / local Postgres.
+#
+# Neon: Dashboard → Connection string → choose "pooled" for the API.
+# Local: docker compose up -d postgres
+#
+# DATABASE_URL=postgresql://worksight:worksight@localhost:5432/worksight
+# DATABASE_URL=postgresql://USER:PASSWORD@HOST/neondb?sslmode=require
+
+DATABASE_URL=

--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'drizzle-kit';
+import 'dotenv/config';
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL ?? 'postgresql://worksight:worksight@localhost:5432/worksight',
+  },
+});

--- a/apps/api/drizzle/0000_steep_silvermane.sql
+++ b/apps/api/drizzle/0000_steep_silvermane.sql
@@ -1,0 +1,67 @@
+CREATE TABLE "activities" (
+	"id" text PRIMARY KEY NOT NULL,
+	"source_id" text NOT NULL,
+	"external_id" text NOT NULL,
+	"employee_id" text NOT NULL,
+	"type" text NOT NULL,
+	"timestamp" timestamp with time zone NOT NULL,
+	"description" text NOT NULL,
+	"is_after_hours" boolean DEFAULT false NOT NULL,
+	"is_weekend" boolean DEFAULT false NOT NULL,
+	"is_urgent" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "assignments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"employee_id" text NOT NULL,
+	"source_id" text,
+	"external_id" text,
+	"type" text NOT NULL,
+	"title" text,
+	"status" text DEFAULT 'todo' NOT NULL,
+	"sprint" text,
+	"epic" text,
+	"points" integer,
+	"priority" text DEFAULT 'low' NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "data_sources" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"type" text[] NOT NULL,
+	"base_url" text NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"modules" text[] NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "employees" (
+	"id" text PRIMARY KEY NOT NULL,
+	"internal_id" text NOT NULL,
+	"email" text NOT NULL,
+	"name" text NOT NULL,
+	"role" text NOT NULL,
+	"department" text[] NOT NULL,
+	"team" text,
+	"manager_id" text,
+	"date_joined" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "employees_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "teams" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"department" text NOT NULL,
+	"manager_id" text NOT NULL,
+	"member_ids" text[] NOT NULL,
+	"parent_team_id" text,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);

--- a/apps/api/drizzle/meta/0000_snapshot.json
+++ b/apps/api/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,410 @@
+{
+  "id": "962e2728-6476-4e8c-af75-a657e96707af",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activities": {
+      "name": "activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_after_hours": {
+          "name": "is_after_hours",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_weekend": {
+          "name": "is_weekend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_urgent": {
+          "name": "is_urgent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assignments": {
+      "name": "assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "sprint": {
+          "name": "sprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epic": {
+          "name": "epic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_sources": {
+      "name": "data_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "modules": {
+          "name": "modules",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.employees": {
+      "name": "employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_joined": {
+          "name": "date_joined",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employees_email_unique": {
+          "name": "employees_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_ids": {
+          "name": "member_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_team_id": {
+          "name": "parent_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1786364809076,
+      "tag": "0000_steep_silvermane",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,12 @@
     "clean": "rm -rf dist",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
+    "db:seed": "tsx src/db/seed.ts",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@nestjs/common": "^11.1.6",
@@ -27,6 +32,8 @@
     "@supabase/supabase-js": "^2.58.0",
     "@worksight/common": "workspace:*",
     "class-transformer": "^0.5.1",
+    "drizzle-orm": "^0.45.2",
+    "postgres": "^3.4.9",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2"
   },
@@ -37,7 +44,10 @@
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.5.2",
+    "@types/pg": "^8.21.0",
     "@types/supertest": "^6.0.3",
+    "dotenv": "^17.4.2",
+    "drizzle-kit": "^0.31.10",
     "jest": "^30.2.0",
     "source-map-support": "^0.5.21",
     "supertest": "^7.1.4",
@@ -45,6 +55,7 @@
     "ts-loader": "^9.5.4",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.2"
   }
 }

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,20 +1,26 @@
 import { Controller, Get, Header } from '@nestjs/common';
+import { AppService } from './app.service';
 
 @Controller()
 export class AppController {
+  constructor(private readonly appService: AppService) {}
+
   @Get()
   getHello(): string {
-    return `hello`;
+    return 'hello';
   }
 
   @Get('ping')
   @Header('Content-Type', 'text/plain')
   ping() {
-    return `pong`;
+    return 'pong';
   }
 
   @Get('health')
   health() {
-    return { status: 'ok', uptime: process.uptime() };
+    return {
+      ...this.appService.getHealth(),
+      uptime: process.uptime(),
+    };
   }
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { DbModule } from './db/db.module';
 import { TasksModule } from './tasks/tasks.module';
 import { UsersModule } from './users/users.module';
 
 @Module({
-  imports: [UsersModule, TasksModule],
+  imports: [DbModule, UsersModule, TasksModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -1,8 +1,19 @@
 import { Injectable } from '@nestjs/common';
+import { DbService } from './db/db.service';
 
 @Injectable()
 export class AppService {
+  constructor(private readonly db: DbService) {}
+
   getHello(): string {
     return 'Hello World!';
+  }
+
+  getHealth() {
+    return {
+      status: 'ok',
+      dataBackend: this.db.backend,
+      databaseUrlConfigured: Boolean(process.env.DATABASE_URL?.trim()),
+    };
   }
 }

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -1,0 +1,28 @@
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import * as schema from './schema';
+
+export type AppDatabase = PostgresJsDatabase<typeof schema>;
+
+export type DatabaseHandle = {
+  db: AppDatabase;
+  sql: ReturnType<typeof postgres>;
+};
+
+/**
+ * Create a Drizzle client when `DATABASE_URL` is set (Neon or local Postgres).
+ * Returns null so the API can keep serving `@worksight/common` fixtures.
+ */
+export function createDatabase(connectionString = process.env.DATABASE_URL): DatabaseHandle | null {
+  const url = connectionString?.trim();
+  if (!url) {
+    return null;
+  }
+
+  const sql = postgres(url, {
+    max: 10,
+    prepare: false, // required for Neon serverless / pooled connections
+  });
+  const db = drizzle(sql, { schema });
+  return { db, sql };
+}

--- a/apps/api/src/db/db.module.ts
+++ b/apps/api/src/db/db.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { DbService } from './db.service';
+
+@Global()
+@Module({
+  providers: [DbService],
+  exports: [DbService],
+})
+export class DbModule {}

--- a/apps/api/src/db/db.service.ts
+++ b/apps/api/src/db/db.service.ts
@@ -1,0 +1,133 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  Optional,
+} from '@nestjs/common';
+import {
+  Activity,
+  Assignment,
+  EmployeeLookup,
+  EmployeeProfile,
+  Team,
+} from '@worksight/common';
+import { eq } from 'drizzle-orm';
+import { createDatabase, type AppDatabase, type DatabaseHandle } from './client';
+import { toActivity, toAssignment, toEmployeeProfile, toTeam } from './mappers';
+import { activities, assignments, employees, teams } from './schema';
+
+export type DataBackend = 'postgres' | 'fixtures';
+
+@Injectable()
+export class DbService implements OnModuleDestroy {
+  private readonly logger = new Logger(DbService.name);
+  private readonly handle: DatabaseHandle | null;
+
+  constructor(@Optional() handle?: DatabaseHandle | null) {
+    this.handle = handle === undefined ? createDatabase() : handle;
+    if (this.handle) {
+      this.logger.log('Postgres data backend enabled (DATABASE_URL set)');
+    } else {
+      loggerFixture(this.logger);
+    }
+  }
+
+  get backend(): DataBackend {
+    return this.handle ? 'postgres' : 'fixtures';
+  }
+
+  get enabled(): boolean {
+    return this.handle !== null;
+  }
+
+  get db(): AppDatabase {
+    if (!this.handle) {
+      throw new Error('Database is not configured (DATABASE_URL missing)');
+    }
+    return this.handle.db;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.handle) {
+      await this.handle.sql.end({ timeout: 5 });
+    }
+  }
+
+  async listEmployees(): Promise<EmployeeProfile[]> {
+    const rows = await this.db.select().from(employees);
+    return rows.map(toEmployeeProfile);
+  }
+
+  async getEmployeeById(id: string): Promise<EmployeeProfile | null> {
+    const [row] = await this.db.select().from(employees).where(eq(employees.id, id)).limit(1);
+    return row ? toEmployeeProfile(row) : null;
+  }
+
+  async getEmployeeStats(): Promise<ReturnType<EmployeeLookup['getStats']>> {
+    const profiles = await this.listEmployees();
+    return new EmployeeLookup(profiles).getStats();
+  }
+
+  async listTeams(): Promise<Team[]> {
+    const rows = await this.db.select().from(teams);
+    return rows.map(toTeam);
+  }
+
+  async getTeamById(id: string): Promise<Team | null> {
+    const [row] = await this.db.select().from(teams).where(eq(teams.id, id)).limit(1);
+    return row ? toTeam(row) : null;
+  }
+
+  async listAssignments(employeeId?: string): Promise<Assignment[]> {
+    const rows = employeeId
+      ? await this.db.select().from(assignments).where(eq(assignments.employeeId, employeeId))
+      : await this.db.select().from(assignments);
+    return rows.map(toAssignment);
+  }
+
+  async getAssignmentById(id: string): Promise<Assignment | null> {
+    const [row] = await this.db.select().from(assignments).where(eq(assignments.id, id)).limit(1);
+    return row ? toAssignment(row) : null;
+  }
+
+  async listActivities(employeeId?: string): Promise<Activity[]> {
+    const rows = employeeId
+      ? await this.db.select().from(activities).where(eq(activities.employeeId, employeeId))
+      : await this.db.select().from(activities);
+    return rows.map(toActivity);
+  }
+
+  async getAssignmentStats(employeeId: string) {
+    const employeeAssignments = await this.listAssignments(employeeId);
+    const employeeActivities = await this.listActivities(employeeId);
+
+    const completed = employeeAssignments.filter(a => a.status === 'completed');
+    const totalStoryPoints = employeeAssignments.reduce((sum, t) => sum + (t.points ?? 0), 0);
+    const completedStoryPoints = completed.reduce((sum, t) => sum + (t.points ?? 0), 0);
+    const afterHours = employeeActivities.filter(a => a.is_after_hours).length;
+    const weekend = employeeActivities.filter(a => a.is_weekend).length;
+    const urgent = employeeActivities.filter(a => a.is_urgent).length;
+
+    return {
+      totalTasks: employeeAssignments.length,
+      completedTasks: completed.length,
+      completionRate: employeeAssignments.length
+        ? (completed.length / employeeAssignments.length) * 100
+        : 0,
+      totalStoryPoints,
+      completedStoryPoints,
+      storyPointsCompletionRate: totalStoryPoints
+        ? (completedStoryPoints / totalStoryPoints) * 100
+        : 0,
+      totalActivities: employeeActivities.length,
+      afterHoursActivities: afterHours,
+      weekendActivities: weekend,
+      urgentActivities: urgent,
+      workLifeBalanceScore: Math.max(0, 100 - afterHours * 10 - weekend * 5),
+    };
+  }
+}
+
+function loggerFixture(logger: Logger): void {
+  logger.log('Fixture data backend (set DATABASE_URL for Neon/Postgres)');
+}

--- a/apps/api/src/db/mappers.ts
+++ b/apps/api/src/db/mappers.ts
@@ -1,0 +1,97 @@
+import type {
+  Activity,
+  ActivityType,
+  Assignment,
+  AssignmentPriority,
+  AssignmentStatus,
+  AssignmentType,
+  DataSource,
+  EmployeeProfile,
+  Team,
+} from '@worksight/common';
+import type { ActivityRow, AssignmentRow, DataSourceRow, EmployeeRow, TeamRow } from './schema';
+
+export function toEmployeeProfile(row: EmployeeRow): EmployeeProfile {
+  return {
+    id: row.id,
+    internal_id: row.internalId,
+    email: row.email,
+    name: row.name,
+    role: row.role as EmployeeProfile['role'],
+    department: row.department as EmployeeProfile['department'],
+    team: row.team ?? undefined,
+    manager_id: row.managerId ?? undefined,
+    date_joined: row.dateJoined,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+  };
+}
+
+export function toTeam(row: TeamRow): Team {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? undefined,
+    department: row.department as Team['department'],
+    manager_id: row.managerId,
+    member_ids: row.memberIds,
+    parent_team_id: row.parentTeamId,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+  };
+}
+
+export function toAssignment(row: AssignmentRow): Assignment {
+  return {
+    id: row.id,
+    employee_id: row.employeeId,
+    source_id: row.sourceId,
+    external_id: row.externalId,
+    type: row.type as AssignmentType,
+    title: row.title,
+    status: row.status as AssignmentStatus,
+    sprint: row.sprint,
+    epic: row.epic,
+    points: row.points,
+    priority: row.priority as AssignmentPriority,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+  };
+}
+
+export function toActivity(row: ActivityRow): Activity {
+  return {
+    id: row.id,
+    source_id: row.sourceId,
+    external_id: row.externalId,
+    employee_id: row.employeeId,
+    type: row.type as ActivityType,
+    timestamp: row.timestamp,
+    description: row.description,
+    is_after_hours: row.isAfterHours,
+    is_weekend: row.isWeekend,
+    is_urgent: row.isUrgent,
+    created_at: row.createdAt,
+  };
+}
+
+export function toDataSource(row: DataSourceRow): DataSource {
+  return {
+    id: row.id,
+    name: row.name,
+    type: row.type as DataSource['type'],
+    base_url: row.baseUrl,
+    is_active: row.isActive,
+    modules: row.modules,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+  };
+}
+
+/** Empty / sentinel manager ids from fixtures → SQL NULL */
+export function normalizeOptionalId(value: string | null | undefined): string | null {
+  if (value == null || value === '' || value === 'admin') {
+    return null;
+  }
+  return value;
+}

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,0 +1,80 @@
+import { boolean, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+/**
+ * Postgres schema mirrored from `@worksight/common` types.
+ * IDs are `text` (not uuid) because shared fixtures include non-RFC UUIDs
+ * and sentinel manager ids like "" / "admin".
+ */
+
+export const dataSources = pgTable('data_sources', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  type: text('type').array().notNull(),
+  baseUrl: text('base_url').notNull(),
+  isActive: boolean('is_active').notNull().default(true),
+  modules: text('modules').array().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+});
+
+export const employees = pgTable('employees', {
+  id: text('id').primaryKey(),
+  internalId: text('internal_id').notNull(),
+  email: text('email').notNull().unique(),
+  name: text('name').notNull(),
+  role: text('role').notNull(),
+  department: text('department').array().notNull(),
+  team: text('team'),
+  managerId: text('manager_id'),
+  dateJoined: timestamp('date_joined', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+});
+
+export const teams = pgTable('teams', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  description: text('description'),
+  department: text('department').notNull(),
+  managerId: text('manager_id').notNull(),
+  memberIds: text('member_ids').array().notNull(),
+  parentTeamId: text('parent_team_id'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+});
+
+export const assignments = pgTable('assignments', {
+  id: text('id').primaryKey(),
+  employeeId: text('employee_id').notNull(),
+  sourceId: text('source_id'),
+  externalId: text('external_id'),
+  type: text('type').notNull(),
+  title: text('title'),
+  status: text('status').notNull().default('todo'),
+  sprint: text('sprint'),
+  epic: text('epic'),
+  points: integer('points'),
+  priority: text('priority').notNull().default('low'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+});
+
+export const activities = pgTable('activities', {
+  id: text('id').primaryKey(),
+  sourceId: text('source_id').notNull(),
+  externalId: text('external_id').notNull(),
+  employeeId: text('employee_id').notNull(),
+  type: text('type').notNull(),
+  timestamp: timestamp('timestamp', { withTimezone: true }).notNull(),
+  description: text('description').notNull(),
+  isAfterHours: boolean('is_after_hours').notNull().default(false),
+  isWeekend: boolean('is_weekend').notNull().default(false),
+  isUrgent: boolean('is_urgent').notNull().default(false),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+});
+
+export type EmployeeRow = typeof employees.$inferSelect;
+export type TeamRow = typeof teams.$inferSelect;
+export type AssignmentRow = typeof assignments.$inferSelect;
+export type ActivityRow = typeof activities.$inferSelect;
+export type DataSourceRow = typeof dataSources.$inferSelect;

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -1,0 +1,122 @@
+/**
+ * Seed Neon/local Postgres from `@worksight/common` fixtures.
+ *
+ *   DATABASE_URL=postgres://... pnpm --filter @worksight/api db:seed
+ */
+import 'dotenv/config';
+
+import {
+  Activities,
+  Assignments,
+  DataSources,
+  Employees,
+  Teams,
+} from '@worksight/common';
+import { createDatabase } from './client';
+import { normalizeOptionalId } from './mappers';
+import { activities, assignments, dataSources, employees, teams } from './schema';
+
+async function seed() {
+  const handle = createDatabase(process.env.DATABASE_URL);
+  if (!handle) {
+    throw new Error('DATABASE_URL is required to seed');
+  }
+
+  const { db, sql } = handle;
+
+  console.log('Seeding WorkSight tables from @worksight/common fixtures…');
+
+  await db.delete(activities);
+  await db.delete(assignments);
+  await db.delete(teams);
+  await db.delete(employees);
+  await db.delete(dataSources);
+
+  await db.insert(dataSources).values(
+    DataSources.map(ds => ({
+      id: ds.id,
+      name: ds.name,
+      type: [...ds.type],
+      baseUrl: ds.base_url,
+      isActive: ds.is_active,
+      modules: [...ds.modules],
+      createdAt: ds.created_at,
+      updatedAt: ds.updated_at,
+    }))
+  );
+
+  await db.insert(employees).values(
+    Employees.map(e => ({
+      id: e.id,
+      internalId: e.internal_id,
+      email: e.email,
+      name: e.name,
+      role: e.role,
+      department: [...e.department],
+      team: e.team ?? null,
+      managerId: normalizeOptionalId(e.manager_id),
+      dateJoined: e.date_joined,
+      createdAt: e.created_at,
+      updatedAt: e.updated_at,
+    }))
+  );
+
+  await db.insert(teams).values(
+    Teams.map(t => ({
+      id: t.id,
+      name: t.name,
+      description: t.description ?? null,
+      department: t.department,
+      managerId: t.manager_id,
+      memberIds: [...t.member_ids],
+      parentTeamId: t.parent_team_id ?? null,
+      createdAt: t.created_at,
+      updatedAt: t.updated_at,
+    }))
+  );
+
+  await db.insert(assignments).values(
+    Assignments.map(a => ({
+      id: a.id,
+      employeeId: a.employee_id,
+      sourceId: a.source_id,
+      externalId: a.external_id,
+      type: a.type,
+      title: a.title,
+      status: a.status,
+      sprint: a.sprint,
+      epic: a.epic,
+      points: a.points,
+      priority: a.priority,
+      createdAt: a.created_at,
+      updatedAt: a.updated_at,
+    }))
+  );
+
+  await db.insert(activities).values(
+    Activities.map(a => ({
+      id: a.id,
+      sourceId: a.source_id,
+      externalId: a.external_id,
+      employeeId: a.employee_id,
+      type: a.type,
+      timestamp: a.timestamp,
+      description: a.description,
+      isAfterHours: a.is_after_hours,
+      isWeekend: a.is_weekend,
+      isUrgent: a.is_urgent,
+      createdAt: a.created_at,
+    }))
+  );
+
+  console.log(
+    `Done: ${DataSources.length} data sources, ${Employees.length} employees, ${Teams.length} teams, ${Assignments.length} assignments, ${Activities.length} activities`
+  );
+
+  await sql.end({ timeout: 5 });
+}
+
+seed().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,7 +1,10 @@
 import { ClassSerializerInterceptor, Logger } from '@nestjs/common';
 import { NestFactory, Reflector } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { config as loadEnv } from 'dotenv';
 import { AppModule } from './app.module';
+
+loadEnv();
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -29,6 +32,10 @@ async function bootstrap() {
 
   await app.listen(port);
   logger.log(`API listening on http://localhost:${port} (CORS: ${corsOrigins.join(', ')})`);
-  logger.log('Data is fixture-backed from @worksight/common — not Supabase.');
+  logger.log(
+    process.env.DATABASE_URL?.trim()
+      ? 'Data backend: Postgres/Neon (DATABASE_URL set).'
+      : 'Data backend: @worksight/common fixtures (set DATABASE_URL for Neon/Postgres).'
+  );
 }
 bootstrap();

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -7,7 +7,7 @@ export class TasksController {
   constructor(private readonly tasksService: TasksService) {}
 
   @Get()
-  getAll(@Query('employee_id') employeeId?: string): Assignment[] {
+  getAll(@Query('employee_id') employeeId?: string): Promise<Assignment[]> {
     return this.tasksService.findAll(employeeId);
   }
 
@@ -17,8 +17,8 @@ export class TasksController {
   }
 
   @Get(':id')
-  getOne(@Param('id') id: string): Assignment {
-    const assignment = this.tasksService.findById(id);
+  async getOne(@Param('id') id: string): Promise<Assignment> {
+    const assignment = await this.tasksService.findById(id);
     if (!assignment) {
       throw new NotFoundException(`Task ${id} not found`);
     }
@@ -31,7 +31,7 @@ export class ActivitiesController {
   constructor(private readonly tasksService: TasksService) {}
 
   @Get()
-  getAll(@Query('employee_id') employeeId?: string): Activity[] {
+  getAll(@Query('employee_id') employeeId?: string): Promise<Activity[]> {
     return this.tasksService.findAllActivities(employeeId);
   }
 }

--- a/apps/api/src/tasks/tasks.service.spec.ts
+++ b/apps/api/src/tasks/tasks.service.spec.ts
@@ -8,33 +8,33 @@ describe('TasksService', () => {
     service = new TasksService();
   });
 
-  it('returns the shared assignment fixtures', () => {
-    expect(service.findAll()).toEqual(Assignments);
+  it('returns the shared assignment fixtures', async () => {
+    expect(await service.findAll()).toEqual(Assignments);
   });
 
-  it('filters assignments by employee', () => {
+  it('filters assignments by employee', async () => {
     const employeeId = Assignments[0].employee_id;
     const expected = Assignments.filter(a => a.employee_id === employeeId);
-    expect(service.findAll(employeeId)).toEqual(expected);
+    expect(await service.findAll(employeeId)).toEqual(expected);
   });
 
-  it('finds an assignment by id', () => {
-    expect(service.findById(Assignments[0].id)).toEqual(Assignments[0]);
-    expect(service.findById('does-not-exist')).toBeNull();
+  it('finds an assignment by id', async () => {
+    expect(await service.findById(Assignments[0].id)).toEqual(Assignments[0]);
+    expect(await service.findById('does-not-exist')).toBeNull();
   });
 
-  it('computes per-employee stats from the fixtures', () => {
+  it('computes per-employee stats from the fixtures', async () => {
     const employeeId = Assignments[0].employee_id;
     const expectedTotal = Assignments.filter(a => a.employee_id === employeeId).length;
-    const stats = service.getStatsForEmployee(employeeId);
+    const stats = await service.getStatsForEmployee(employeeId);
     expect(stats.totalTasks).toBe(expectedTotal);
     expect(stats.completionRate).toBeGreaterThanOrEqual(0);
   });
 
-  it('returns the shared activity fixtures', () => {
-    expect(service.findAllActivities()).toEqual(Activities);
+  it('returns the shared activity fixtures', async () => {
+    expect(await service.findAllActivities()).toEqual(Activities);
     const employeeId = Activities[0].employee_id;
     const expected = Activities.filter(a => a.employee_id === employeeId);
-    expect(service.findAllActivities(employeeId)).toEqual(expected);
+    expect(await service.findAllActivities(employeeId)).toEqual(expected);
   });
 });

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -1,27 +1,44 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { Activity, ActivityLookup, Assignment, AssignmentLookup } from '@worksight/common';
+import { DbService } from '../db/db.service';
 
 @Injectable()
 export class TasksService {
   private readonly assignments = new AssignmentLookup();
   private readonly activities = new ActivityLookup();
 
-  findAll(employeeId?: string): Assignment[] {
+  constructor(@Optional() private readonly db?: DbService) {}
+
+  async findAll(employeeId?: string): Promise<Assignment[]> {
+    if (this.db?.enabled) {
+      return this.db.listAssignments(employeeId);
+    }
     if (employeeId) {
       return this.assignments.getAssignmentsByEmployee(employeeId).all();
     }
     return this.assignments.all();
   }
 
-  findById(id: string): Assignment | null {
+  async findById(id: string): Promise<Assignment | null> {
+    if (this.db?.enabled) {
+      return this.db.getAssignmentById(id);
+    }
     return this.assignments.filter({ id }).first();
   }
 
-  getStatsForEmployee(employeeId: string): ReturnType<AssignmentLookup['getStats']> {
+  async getStatsForEmployee(
+    employeeId: string
+  ): Promise<ReturnType<AssignmentLookup['getStats']>> {
+    if (this.db?.enabled) {
+      return this.db.getAssignmentStats(employeeId);
+    }
     return this.assignments.getStats(employeeId);
   }
 
-  findAllActivities(employeeId?: string): Activity[] {
+  async findAllActivities(employeeId?: string): Promise<Activity[]> {
+    if (this.db?.enabled) {
+      return this.db.listActivities(employeeId);
+    }
     if (employeeId) {
       return this.activities.getActivitiesByEmployee(employeeId).all();
     }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -7,7 +7,7 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get()
-  getAll(): EmployeeProfile[] {
+  getAll(): Promise<EmployeeProfile[]> {
     return this.usersService.findAll();
   }
 
@@ -17,8 +17,8 @@ export class UsersController {
   }
 
   @Get(':id')
-  getOne(@Param('id') id: string): EmployeeProfile {
-    const employee = this.usersService.findById(id);
+  async getOne(@Param('id') id: string): Promise<EmployeeProfile> {
+    const employee = await this.usersService.findById(id);
     if (!employee) {
       throw new NotFoundException(`User ${id} not found`);
     }
@@ -31,13 +31,13 @@ export class TeamsController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get()
-  getAll(): Team[] {
+  getAll(): Promise<Team[]> {
     return this.usersService.findAllTeams();
   }
 
   @Get(':id')
-  getOne(@Param('id') id: string): Team {
-    const team = this.usersService.findTeamById(id);
+  async getOne(@Param('id') id: string): Promise<Team> {
+    const team = await this.usersService.findTeamById(id);
     if (!team) {
       throw new NotFoundException(`Team ${id} not found`);
     }

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -8,29 +8,29 @@ describe('UsersService', () => {
     service = new UsersService();
   });
 
-  it('returns the shared employee fixtures', () => {
-    expect(service.findAll()).toEqual(Employees);
-    expect(service.findAll().length).toBeGreaterThan(0);
+  it('returns the shared employee fixtures', async () => {
+    expect(await service.findAll()).toEqual(Employees);
+    expect((await service.findAll()).length).toBeGreaterThan(0);
   });
 
-  it('finds an employee by id', () => {
+  it('finds an employee by id', async () => {
     const employee = Employees[0];
-    expect(service.findById(employee.id)).toEqual(employee);
+    expect(await service.findById(employee.id)).toEqual(employee);
   });
 
-  it('returns null for an unknown employee id', () => {
-    expect(service.findById('does-not-exist')).toBeNull();
+  it('returns null for an unknown employee id', async () => {
+    expect(await service.findById('does-not-exist')).toBeNull();
   });
 
-  it('computes stats over the shared fixtures', () => {
-    const stats = service.getStats();
+  it('computes stats over the shared fixtures', async () => {
+    const stats = await service.getStats();
     expect(stats.totalEmployees).toBe(Employees.length);
     const employeeRole = stats.roles.find(r => r.role === 'employee');
     expect(employeeRole?.count).toBe(Employees.filter(e => e.role === 'employee').length);
   });
 
-  it('returns the shared team fixtures', () => {
-    expect(service.findAllTeams()).toEqual(Teams);
-    expect(service.findTeamById(Teams[0].id)).toEqual(Teams[0]);
+  it('returns the shared team fixtures', async () => {
+    expect(await service.findAllTeams()).toEqual(Teams);
+    expect(await service.findTeamById(Teams[0].id)).toEqual(Teams[0]);
   });
 });

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,28 +1,46 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { EmployeeLookup, EmployeeProfile, Team, TeamLookup, Teams } from '@worksight/common';
+import { DbService } from '../db/db.service';
 
 @Injectable()
 export class UsersService {
   private readonly employees = new EmployeeLookup();
   private readonly teams = new TeamLookup(Teams);
 
-  findAll(): EmployeeProfile[] {
+  constructor(@Optional() private readonly db?: DbService) {}
+
+  async findAll(): Promise<EmployeeProfile[]> {
+    if (this.db?.enabled) {
+      return this.db.listEmployees();
+    }
     return this.employees.all();
   }
 
-  findById(id: string): EmployeeProfile | null {
+  async findById(id: string): Promise<EmployeeProfile | null> {
+    if (this.db?.enabled) {
+      return this.db.getEmployeeById(id);
+    }
     return this.employees.getById(id);
   }
 
-  getStats(): ReturnType<EmployeeLookup['getStats']> {
+  async getStats(): Promise<ReturnType<EmployeeLookup['getStats']>> {
+    if (this.db?.enabled) {
+      return this.db.getEmployeeStats();
+    }
     return this.employees.getStats();
   }
 
-  findAllTeams(): Team[] {
+  async findAllTeams(): Promise<Team[]> {
+    if (this.db?.enabled) {
+      return this.db.listTeams();
+    }
     return this.teams.all();
   }
 
-  findTeamById(id: string): Team | null {
+  async findTeamById(id: string): Promise<Team | null> {
+    if (this.db?.enabled) {
+      return this.db.getTeamById(id);
+    }
     return this.teams.getById(id);
   }
 }

--- a/doc/DATABASE.md
+++ b/doc/DATABASE.md
@@ -1,0 +1,37 @@
+# Database (Neon / Postgres)
+
+The Nest API serves `@worksight/common` fixtures by default. Set `DATABASE_URL`
+to switch list/detail/stats routes to Postgres (Neon or local).
+
+## Local Postgres
+
+```bash
+docker compose up -d postgres
+export DATABASE_URL=postgresql://worksight:worksight@localhost:5432/worksight
+pnpm --filter @worksight/common build
+pnpm --filter @worksight/api db:push
+pnpm --filter @worksight/api db:seed
+DATABASE_URL="$DATABASE_URL" pnpm --filter @worksight/api start:prod
+curl -s localhost:3001/health
+# {"status":"ok","dataBackend":"postgres",...}
+```
+
+## Neon
+
+1. Create a project at [neon.tech](https://neon.tech).
+2. Copy the **pooled** connection string into `apps/api/.env` as `DATABASE_URL`.
+3. Run `db:push` then `db:seed` (same commands as above).
+4. Deploy the API with that env var (Docker / Fly / Railway — not Vercel
+   serverless Nest today).
+
+## Scripts (`@worksight/api`)
+
+| Script        | Purpose                                      |
+| ------------- | -------------------------------------------- |
+| `db:generate` | Generate SQL migrations from Drizzle schema  |
+| `db:push`     | Push schema to the database (dev-friendly)   |
+| `db:migrate`  | Apply generated migrations                   |
+| `db:seed`     | Load fixtures from `@worksight/common`       |
+| `db:studio`   | Open Drizzle Studio                          |
+
+IDs are stored as `text` so fixture values that are not RFC UUIDs still seed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,23 @@
 version: '3.9'
 services:
+  postgres:
+    image: docker.io/library/postgres:16-alpine
+    container_name: worksight_postgres
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_USER: worksight
+      POSTGRES_PASSWORD: worksight
+      POSTGRES_DB: worksight
+    volumes:
+      - worksight_pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U worksight -d worksight']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
   web:
     container_name: worksight_web
     build:
@@ -29,4 +47,7 @@ services:
     depends_on:
       - web
       - docs
+
+volumes:
+  worksight_pg:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 16.5.0
       jest:
         specifier: ^30.2.0
-        version: 30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
+        version: 30.3.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -62,7 +62,7 @@ importers:
         version: 3.6.2
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.20.6
         version: 4.21.0
@@ -102,6 +102,12 @@ importers:
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.21.0)(postgres@3.4.9)
+      postgres:
+        specifier: ^3.4.9
+        version: 3.4.9
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -127,9 +133,18 @@ importers:
       '@types/node':
         specifier: ^24.5.2
         version: 24.10.1
+      '@types/pg':
+        specifier: ^8.21.0
+        version: 8.21.0
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       jest:
         specifier: ^30.2.0
         version: 30.3.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
@@ -141,7 +156,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.4.4
-        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       ts-loader:
         specifier: ^9.5.4
         version: 9.6.2(typescript@5.9.3)(webpack@5.106.2)
@@ -151,6 +166,9 @@ importers:
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -769,6 +787,9 @@ packages:
       search-insights:
         optional: true
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@dual-bundle/import-meta-resolve@4.2.1':
     resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
 
@@ -780,6 +801,14 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -799,6 +828,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -815,6 +850,12 @@ packages:
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.21.5':
@@ -835,6 +876,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -853,6 +900,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.21.5':
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
@@ -869,6 +922,12 @@ packages:
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.21.5':
@@ -889,6 +948,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.21.5':
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
@@ -905,6 +970,12 @@ packages:
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -925,6 +996,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.21.5':
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
@@ -941,6 +1018,12 @@ packages:
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.21.5':
@@ -961,6 +1044,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.21.5':
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
@@ -977,6 +1066,12 @@ packages:
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.21.5':
@@ -997,6 +1092,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.21.5':
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
@@ -1013,6 +1114,12 @@ packages:
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -1033,6 +1140,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.21.5':
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
@@ -1051,6 +1164,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -1067,6 +1186,12 @@ packages:
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.21.5':
@@ -1099,6 +1224,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
@@ -1127,6 +1258,12 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -1159,6 +1296,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
@@ -1176,6 +1319,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
@@ -1195,6 +1344,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
@@ -1211,6 +1366,12 @@ packages:
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.21.5':
@@ -2947,6 +3108,9 @@ packages:
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
+  '@types/pg@8.21.0':
+    resolution: {integrity: sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==}
+
   '@types/qs@6.15.1':
     resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
 
@@ -4007,6 +4171,106 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -4092,6 +4356,11 @@ packages:
 
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -5610,6 +5879,17 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5677,6 +5957,26 @@ packages:
   postcss@8.5.22:
     resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres@3.4.9:
+    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
+    engines: {node: '>=12'}
 
   preact@10.28.3:
     resolution: {integrity: sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==}
@@ -6833,6 +7133,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -7340,6 +7644,8 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
   '@emnapi/core@1.11.2':
@@ -7358,6 +7664,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -7365,6 +7681,9 @@ snapshots:
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
@@ -7376,6 +7695,9 @@ snapshots:
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
   '@esbuild/android-arm@0.21.5':
     optional: true
 
@@ -7383,6 +7705,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.21.5':
@@ -7394,6 +7719,9 @@ snapshots:
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
@@ -7401,6 +7729,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
@@ -7412,6 +7743,9 @@ snapshots:
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
@@ -7419,6 +7753,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -7430,6 +7767,9 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
@@ -7437,6 +7777,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
@@ -7448,6 +7791,9 @@ snapshots:
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
@@ -7455,6 +7801,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
@@ -7466,6 +7815,9 @@ snapshots:
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
@@ -7473,6 +7825,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -7484,6 +7839,9 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
@@ -7493,6 +7851,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
@@ -7500,6 +7861,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -7517,6 +7881,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
@@ -7530,6 +7897,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -7547,6 +7917,9 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
     optional: true
 
@@ -7554,6 +7927,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
@@ -7565,6 +7941,9 @@ snapshots:
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
@@ -7572,6 +7951,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
@@ -7927,41 +8309,6 @@ snapshots:
       jest-message-util: 30.3.0
       jest-util: 30.3.0
       slash: 3.0.0
-
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 20.19.25
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
 
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))':
     dependencies:
@@ -9280,6 +9627,12 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/pg@8.21.0':
+    dependencies:
+      '@types/node': 20.19.25
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+
   '@types/qs@6.15.1': {}
 
   '@types/range-parser@1.2.7': {}
@@ -10375,6 +10728,20 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dotenv@17.4.2: {}
+
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.21.0
+
+  drizzle-orm@0.45.2(@types/pg@8.21.0)(postgres@3.4.9):
+    optionalDependencies:
+      '@types/pg': 8.21.0
+      postgres: 3.4.9
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -10516,6 +10883,31 @@ snapshots:
       is-symbol: 1.1.1
 
   es-toolkit@1.46.1: {}
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -11529,25 +11921,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   jest-cli@30.3.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
@@ -11566,38 +11939,6 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
-
-  jest-config@30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.25
-      ts-node: 10.9.2(@types/node@20.19.25)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)):
     dependencies:
@@ -11883,19 +12224,6 @@ snapshots:
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jest@30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
 
   jest@30.3.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)):
     dependencies:
@@ -12457,6 +12785,18 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
+  pg-int8@1.0.1: {}
+
+  pg-protocol@1.16.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -12507,6 +12847,18 @@ snapshots:
       nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  postgres@3.4.9: {}
 
   preact@10.28.3: {}
 
@@ -13348,27 +13700,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.9
-      jest: 30.3.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.8.5
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      jest-util: 30.3.0
-
-  ts-jest@29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -13395,25 +13727,6 @@ snapshots:
       source-map: 0.7.6
       typescript: 5.9.3
       webpack: 5.106.2
-
-  ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.25
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3):
     dependencies:
@@ -13923,6 +14236,8 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@7.5.13: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
- Nest list/detail/stats routes read Postgres when `DATABASE_URL` is set (Drizzle + `postgres.js`); otherwise keep `@worksight/common` fixtures.
- Schema/migration/seed under `apps/api` (`db:push` / `db:seed`), local Postgres in `docker-compose`, docs in `doc/DATABASE.md`.
- `/health` reports `dataBackend: fixtures | postgres`.

## Note vs existing work
Parallel to **#28** (`feat/api-postgres-url`, raw `pg` + SQL + live Neon + fixture UUID fixes). Pick one persistence approach before merging both — do not land both as-is.

## Test plan
- [ ] `pnpm --filter @worksight/common build && pnpm --filter @worksight/api test` (fixtures)
- [ ] `docker compose up -d postgres` → `db:push` → `db:seed` → boot API with `DATABASE_URL` → `/health` shows `postgres`
- [ ] `/users`, `/teams`, `/tasks`, `/activities` return seeded counts


Made with [Cursor](https://cursor.com)