### PR TITLE
feat(api): mutating task endpoints (Postgres)

### DIFF
--- a/apps/api/src/db/db.service.ts
+++ b/apps/api/src/db/db.service.ts
@@ -18,6 +18,14 @@ import { activities, assignments, employees, teams } from './schema';
 
 export type DataBackend = 'postgres' | 'fixtures';
 
+/** Insert shape for `assignments`, derived from the table so it tracks schema.ts. */
+export type NewAssignmentRow = typeof assignments.$inferInsert;
+
+/** Columns `PATCH /tasks/:id` is allowed to touch. */
+export type AssignmentPatch = Partial<
+  Pick<NewAssignmentRow, 'status' | 'priority' | 'title' | 'points'>
+>;
+
 @Injectable()
 export class DbService implements OnModuleDestroy {
   private readonly logger = new Logger(DbService.name);
@@ -125,6 +133,27 @@ export class DbService implements OnModuleDestroy {
       urgentActivities: urgent,
       workLifeBalanceScore: Math.max(0, 100 - afterHours * 10 - weekend * 5),
     };
+  }
+
+  /* ---------------------------------------------------------------- writes */
+
+  /** Insert one assignment and return it mapped back to the shared type. */
+  async createAssignment(values: NewAssignmentRow): Promise<Assignment> {
+    const [row] = await this.db.insert(assignments).values(values).returning();
+    return toAssignment(row);
+  }
+
+  /**
+   * Apply a partial update. Returns `null` when no row matched `id` so callers
+   * can turn that into a 404. `updated_at` is bumped server-side.
+   */
+  async updateAssignment(id: string, patch: AssignmentPatch): Promise<Assignment | null> {
+    const [row] = await this.db
+      .update(assignments)
+      .set({ ...patch, updatedAt: new Date() })
+      .where(eq(assignments.id, id))
+      .returning();
+    return row ? toAssignment(row) : null;
   }
 }
 

--- a/apps/api/src/tasks/db-writes.spec.ts
+++ b/apps/api/src/tasks/db-writes.spec.ts
@@ -1,0 +1,95 @@
+import type { DatabaseHandle } from '../db/client';
+import { DbService } from '../db/db.service';
+import type { AssignmentRow } from '../db/schema';
+
+/**
+ * Exercises the `DbService` write helpers against a hand-rolled Drizzle stub —
+ * no Postgres required, so this runs in the default fixture-mode CI lane.
+ */
+
+const row: AssignmentRow = {
+  id: '11111111-1111-4111-8111-111111111111',
+  employeeId: 'emp-1',
+  sourceId: null,
+  externalId: null,
+  type: 'bug',
+  title: 'Fix it',
+  status: 'in_progress',
+  sprint: null,
+  epic: null,
+  points: 3,
+  priority: 'high',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-02T00:00:00Z'),
+};
+
+type Captured = { insertValues?: unknown; setPatch?: Record<string, unknown> };
+
+function stubService(returning: AssignmentRow[]): { service: DbService; captured: Captured } {
+  const captured: Captured = {};
+  const db = {
+    insert: () => ({
+      values: (values: unknown) => {
+        captured.insertValues = values;
+        return { returning: async () => returning };
+      },
+    }),
+    update: () => ({
+      set: (patch: Record<string, unknown>) => {
+        captured.setPatch = patch;
+        return { where: () => ({ returning: async () => returning }) };
+      },
+    }),
+  };
+  const handle = { db, sql: { end: async () => undefined } } as unknown as DatabaseHandle;
+  return { service: new DbService(handle), captured };
+}
+
+describe('DbService write helpers', () => {
+  it('reports the postgres backend when a handle is supplied', () => {
+    const { service } = stubService([row]);
+    expect(service.backend).toBe('postgres');
+    expect(service.enabled).toBe(true);
+  });
+
+  it('inserts and maps the returned row back to an Assignment', async () => {
+    const { service, captured } = stubService([row]);
+    const created = await service.createAssignment({ ...row });
+
+    expect(captured.insertValues).toMatchObject({ id: row.id, employeeId: 'emp-1' });
+    expect(created).toEqual({
+      id: row.id,
+      employee_id: 'emp-1',
+      source_id: null,
+      external_id: null,
+      type: 'bug',
+      title: 'Fix it',
+      status: 'in_progress',
+      sprint: null,
+      epic: null,
+      points: 3,
+      priority: 'high',
+      created_at: row.createdAt,
+      updated_at: row.updatedAt,
+    });
+  });
+
+  it('bumps updated_at on every patch', async () => {
+    const { service, captured } = stubService([row]);
+    await service.updateAssignment(row.id, { status: 'completed' });
+
+    expect(captured.setPatch).toMatchObject({ status: 'completed' });
+    expect(captured.setPatch?.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('returns null when the update matched no row', async () => {
+    const { service } = stubService([]);
+    await expect(service.updateAssignment('missing', { status: 'todo' })).resolves.toBeNull();
+  });
+
+  it('throws a clear error when writes are attempted without a handle', async () => {
+    const fixtureService = new DbService(null);
+    expect(fixtureService.backend).toBe('fixtures');
+    await expect(fixtureService.createAssignment({ ...row })).rejects.toThrow(/DATABASE_URL/);
+  });
+});

--- a/apps/api/src/tasks/task-write.dto.ts
+++ b/apps/api/src/tasks/task-write.dto.ts
@@ -1,0 +1,111 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  AssignmentPriority,
+  AssignmentPrioritySchema,
+  AssignmentSchema,
+  AssignmentStatus,
+  AssignmentStatusSchema,
+  AssignmentType,
+} from '@worksight/common';
+
+/**
+ * Write-side validation for the task endpoints, derived from the shared
+ * `AssignmentSchema` so the API can never drift from `@worksight/common`.
+ *
+ * Zod is not a direct dependency of the API, so the schema constants stay
+ * module-private: exporting them would force `tsc` to name Zod's inferred
+ * types through `packages/common/node_modules` (TS2742). The exported surface
+ * is the two hand-written input types plus the parse functions.
+ */
+
+/**
+ * `PATCH /tasks/:id` — every field optional, unknown keys stripped.
+ *
+ * `status` / `priority` are re-declared from their bare enums instead of being
+ * `.pick()`ed: the shared schema gives them a `.default()`, and `.partial()`
+ * does **not** drop defaults, so an empty PATCH body would otherwise silently
+ * reset both columns to `todo` / `low`.
+ */
+const UpdateAssignmentSchema = AssignmentSchema.pick({
+  title: true,
+  points: true,
+})
+  .partial()
+  .extend({
+    status: AssignmentStatusSchema.optional(),
+    priority: AssignmentPrioritySchema.optional(),
+  });
+
+/**
+ * `POST /tasks` — Assignment-shaped. `employee_id` and `type` are required, a
+ * supplied `id` must be a UUID (one is generated when missing), and `status` /
+ * `priority` fall back to the shared defaults. Timestamps are server-owned:
+ * `created_at` / `updated_at` in the body are ignored rather than rejected.
+ */
+const CreateAssignmentSchema = AssignmentSchema.omit({
+  created_at: true,
+  updated_at: true,
+}).partial({
+  id: true,
+  source_id: true,
+  external_id: true,
+  title: true,
+  sprint: true,
+  epic: true,
+  points: true,
+});
+
+export type CreateAssignmentInput = {
+  id?: string;
+  employee_id: string;
+  source_id?: string | null;
+  external_id?: string | null;
+  type: AssignmentType;
+  title?: string | null;
+  status: AssignmentStatus;
+  sprint?: string | null;
+  epic?: string | null;
+  points?: number | null;
+  priority: AssignmentPriority;
+};
+
+export type UpdateAssignmentInput = {
+  status?: AssignmentStatus;
+  priority?: AssignmentPriority;
+  title?: string | null;
+  points?: number | null;
+};
+
+export function parseCreateAssignment(body: unknown): CreateAssignmentInput {
+  const parsed = CreateAssignmentSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestException(describeIssues(parsed.error));
+  }
+  assertIntegerPoints(parsed.data.points);
+  return parsed.data;
+}
+
+export function parseUpdateAssignment(body: unknown): UpdateAssignmentInput {
+  const parsed = UpdateAssignmentSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestException(describeIssues(parsed.error));
+  }
+  assertIntegerPoints(parsed.data.points);
+  return parsed.data;
+}
+
+type IssueLike = { path: PropertyKey[]; message: string };
+
+/** Flatten Zod issues into one human-readable line for a 400 response. */
+function describeIssues(error: { issues: readonly IssueLike[] }): string {
+  return error.issues
+    .map(issue => `${issue.path.map(String).join('.') || 'body'}: ${issue.message}`)
+    .join('; ');
+}
+
+/** `points` maps to an integer column; reject floats before Postgres does. */
+function assertIntegerPoints(points: number | null | undefined): void {
+  if (typeof points === 'number' && !Number.isInteger(points)) {
+    throw new BadRequestException('points: expected an integer');
+  }
+}

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Get, NotFoundException, Param, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
 import type { Activity, Assignment } from '@worksight/common';
 import { TasksService } from './tasks.service';
 
@@ -23,6 +32,22 @@ export class TasksController {
       throw new NotFoundException(`Task ${id} not found`);
     }
     return assignment;
+  }
+
+  /** Requires DATABASE_URL; 501 in fixture mode. */
+  @Post()
+  create(@Body() body: unknown): Promise<Assignment> {
+    return this.tasksService.create(body);
+  }
+
+  /** Partial update. Requires DATABASE_URL; 501 in fixture mode. */
+  @Patch(':id')
+  async update(@Param('id') id: string, @Body() body: unknown): Promise<Assignment> {
+    const updated = await this.tasksService.update(id, body);
+    if (!updated) {
+      throw new NotFoundException(`Task ${id} not found`);
+    }
+    return updated;
   }
 }
 

--- a/apps/api/src/tasks/tasks.service.spec.ts
+++ b/apps/api/src/tasks/tasks.service.spec.ts
@@ -1,4 +1,6 @@
-import { Activities, Assignments } from '@worksight/common';
+import { BadRequestException, NotImplementedException } from '@nestjs/common';
+import { Activities, Assignment, Assignments } from '@worksight/common';
+import type { DbService } from '../db/db.service';
 import { TasksService } from './tasks.service';
 
 describe('TasksService', () => {
@@ -36,5 +38,139 @@ describe('TasksService', () => {
     const employeeId = Activities[0].employee_id;
     const expected = Activities.filter(a => a.employee_id === employeeId);
     expect(await service.findAllActivities(employeeId)).toEqual(expected);
+  });
+
+  it('refuses writes in fixture mode with a 501', async () => {
+    await expect(service.create({ employee_id: 'e1', type: 'bug' })).rejects.toBeInstanceOf(
+      NotImplementedException
+    );
+    await expect(service.update('any-id', { status: 'completed' })).rejects.toBeInstanceOf(
+      NotImplementedException
+    );
+  });
+
+  it('refuses writes when no DbService is injected at all', async () => {
+    const noDb = new TasksService(undefined);
+    await expect(noDb.create({ employee_id: 'e1', type: 'bug' })).rejects.toThrow(/DATABASE_URL/);
+  });
+});
+
+describe('TasksService writes (postgres backend)', () => {
+  const stored: Assignment = {
+    id: '11111111-1111-4111-8111-111111111111',
+    employee_id: 'emp-1',
+    source_id: null,
+    external_id: null,
+    type: 'bug',
+    title: 'Fix it',
+    status: 'todo',
+    sprint: null,
+    epic: null,
+    points: 3,
+    priority: 'low',
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    updated_at: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  let createAssignment: jest.Mock;
+  let updateAssignment: jest.Mock;
+  let service: TasksService;
+
+  beforeEach(() => {
+    createAssignment = jest.fn().mockResolvedValue(stored);
+    updateAssignment = jest.fn().mockResolvedValue(stored);
+    service = new TasksService({
+      enabled: true,
+      createAssignment,
+      updateAssignment,
+    } as unknown as DbService);
+  });
+
+  it('generates a uuid and applies shared defaults when creating', async () => {
+    await expect(service.create({ employee_id: 'emp-1', type: 'bug' })).resolves.toEqual(stored);
+
+    const row = createAssignment.mock.calls[0][0];
+    expect(row.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(row.employeeId).toBe('emp-1');
+    expect(row.status).toBe('todo');
+    expect(row.priority).toBe('low');
+    expect(row.title).toBeNull();
+    expect(row.points).toBeNull();
+    expect(row.createdAt).toBeInstanceOf(Date);
+    expect(row.updatedAt).toEqual(row.createdAt);
+  });
+
+  it('maps a full Assignment-shaped body onto row columns', async () => {
+    await service.create({
+      id: stored.id,
+      employee_id: 'emp-1',
+      source_id: 'jira',
+      external_id: 'WS-12',
+      type: 'feature',
+      title: 'Ship it',
+      status: 'in_progress',
+      sprint: 'S1',
+      epic: 'E1',
+      points: 5,
+      priority: 'high',
+      created_at: '1999-01-01T00:00:00Z', // server-owned: ignored
+    });
+
+    const row = createAssignment.mock.calls[0][0];
+    expect(row).toMatchObject({
+      id: stored.id,
+      employeeId: 'emp-1',
+      sourceId: 'jira',
+      externalId: 'WS-12',
+      type: 'feature',
+      title: 'Ship it',
+      status: 'in_progress',
+      sprint: 'S1',
+      epic: 'E1',
+      points: 5,
+      priority: 'high',
+    });
+    expect(row.createdAt.getUTCFullYear()).toBeGreaterThan(1999);
+  });
+
+  it('rejects an invalid create body with a 400', async () => {
+    await expect(service.create({ type: 'bug' })).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.create({ employee_id: 'e', type: 'nope' })).rejects.toThrow(/type/);
+    await expect(service.create({ employee_id: 'e', type: 'bug', id: 'nope' })).rejects.toThrow(
+      /id/
+    );
+    await expect(
+      service.create({ employee_id: 'e', type: 'bug', points: 1.5 })
+    ).rejects.toThrow(/points/);
+    expect(createAssignment).not.toHaveBeenCalled();
+  });
+
+  it('sends only the fields present in a patch', async () => {
+    await expect(service.update(stored.id, { status: 'completed' })).resolves.toEqual(stored);
+    expect(updateAssignment).toHaveBeenCalledWith(stored.id, { status: 'completed' });
+  });
+
+  it('allows nulling title and points, and ignores unknown keys', async () => {
+    await service.update(stored.id, { title: null, points: null, employee_id: 'hijack' });
+    expect(updateAssignment).toHaveBeenCalledWith(stored.id, { title: null, points: null });
+  });
+
+  it('does not reset status/priority when the patch omits them', async () => {
+    await service.update(stored.id, { title: 'Renamed' });
+    const patch = updateAssignment.mock.calls[0][1];
+    expect(patch).not.toHaveProperty('status');
+    expect(patch).not.toHaveProperty('priority');
+  });
+
+  it('rejects an empty or invalid patch with a 400', async () => {
+    await expect(service.update(stored.id, {})).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.update(stored.id, { status: 'bogus' })).rejects.toThrow(/status/);
+    await expect(service.update(stored.id, { points: 2.5 })).rejects.toThrow(/points/);
+    expect(updateAssignment).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the id does not exist so the controller can 404', async () => {
+    updateAssignment.mockResolvedValue(null);
+    await expect(service.update('missing', { status: 'todo' })).resolves.toBeNull();
   });
 });

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -1,6 +1,8 @@
-import { Injectable, Optional } from '@nestjs/common';
+import { BadRequestException, Injectable, NotImplementedException, Optional } from '@nestjs/common';
 import { Activity, ActivityLookup, Assignment, AssignmentLookup } from '@worksight/common';
-import { DbService } from '../db/db.service';
+import { randomUUID } from 'node:crypto';
+import { AssignmentPatch, DbService, NewAssignmentRow } from '../db/db.service';
+import { parseCreateAssignment, parseUpdateAssignment } from './task-write.dto';
 
 @Injectable()
 export class TasksService {
@@ -43,5 +45,63 @@ export class TasksService {
       return this.activities.getActivitiesByEmployee(employeeId).all();
     }
     return this.activities.all();
+  }
+
+  /** `POST /tasks` — persist a new assignment. */
+  async create(body: unknown): Promise<Assignment> {
+    const db = this.requireWritableBackend();
+    const input = parseCreateAssignment(body);
+
+    const now = new Date();
+    const row: NewAssignmentRow = {
+      id: input.id ?? randomUUID(),
+      employeeId: input.employee_id,
+      sourceId: input.source_id ?? null,
+      externalId: input.external_id ?? null,
+      type: input.type,
+      title: input.title ?? null,
+      status: input.status,
+      sprint: input.sprint ?? null,
+      epic: input.epic ?? null,
+      points: input.points ?? null,
+      priority: input.priority,
+      createdAt: now,
+      updatedAt: now,
+    };
+    return db.createAssignment(row);
+  }
+
+  /** `PATCH /tasks/:id` — returns `null` when the id does not exist. */
+  async update(id: string, body: unknown): Promise<Assignment | null> {
+    const db = this.requireWritableBackend();
+    const input = parseUpdateAssignment(body);
+
+    const patch: AssignmentPatch = {};
+    if (input.status !== undefined) patch.status = input.status;
+    if (input.priority !== undefined) patch.priority = input.priority;
+    if (input.title !== undefined) patch.title = input.title;
+    if (input.points !== undefined) patch.points = input.points;
+
+    if (Object.keys(patch).length === 0) {
+      throw new BadRequestException(
+        'PATCH body must set at least one of: status, priority, title, points'
+      );
+    }
+    return db.updateAssignment(id, patch);
+  }
+
+  /**
+   * Writes need a real database. In fixture mode the data lives in
+   * `@worksight/common` and is read-only, so we fail loudly (501) rather than
+   * accepting a mutation that silently disappears.
+   */
+  private requireWritableBackend(): DbService {
+    if (!this.db?.enabled) {
+      throw new NotImplementedException(
+        'Task writes require a database backend. Set DATABASE_URL to enable ' +
+          'POST /tasks and PATCH /tasks/:id; fixture mode is read-only.'
+      );
+    }
+    return this.db;
   }
 }


### PR DESCRIPTION
## Summary
- `POST /tasks` and `PATCH /tasks/:id` for assignment creates/updates when the API is on Postgres.
- DbService write helpers + DTO validation; fixture mode stays read-oriented.
- Unit coverage for write path.

Stacked on `feat/neon-persistence` (see also overlap note on that PR vs #28).

## Test plan
- [ ] `pnpm --filter @worksight/api test`
- [ ] With `DATABASE_URL`: create + patch a task; GET reflects changes
- [ ] Without `DATABASE_URL`: writes fail clearly / fixtures still serve GETs


Made with [Cursor](https://cursor.com)