### PR TITLE
feat(api): POST/PATCH tasks on the #28 Postgres stack

### DIFF
--- a/apps/api/src/db/worksight.repository.ts
+++ b/apps/api/src/db/worksight.repository.ts
@@ -118,6 +118,27 @@ type ActivityRow = {
   created_at: Date;
 };
 
+
+/** Insert shape for POST /tasks (timestamps owned by the repository). */
+export type NewAssignmentInput = {
+  id: string;
+  employee_id: string;
+  source_id: string | null;
+  external_id: string | null;
+  type: Assignment['type'];
+  title: string | null;
+  status: Assignment['status'];
+  sprint: string | null;
+  epic: string | null;
+  points: number | null;
+  priority: Assignment['priority'];
+};
+
+/** Columns PATCH /tasks/:id may touch. */
+export type AssignmentPatch = Partial<
+  Pick<Assignment, 'status' | 'priority' | 'title' | 'points'>
+>;
+
 @Injectable()
 export class WorksightRepository {
   constructor(private readonly db: DatabaseService) {}
@@ -167,6 +188,64 @@ export class WorksightRepository {
     const { rows } = await this.db.query<AssignmentRow>(
       `SELECT * FROM assignments WHERE id = $1`,
       [id]
+    );
+    return rows[0] ? toAssignment(rows[0]) : null;
+  }
+
+  /** Insert one assignment and return the mapped shared type. */
+  async createAssignment(input: NewAssignmentInput): Promise<Assignment> {
+    const now = new Date();
+    const { rows } = await this.db.query<AssignmentRow>(
+      `INSERT INTO assignments
+         (id, employee_id, source_id, external_id, type, title, status,
+          sprint, epic, points, priority, created_at, updated_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+       RETURNING *`,
+      [
+        input.id,
+        input.employee_id,
+        input.source_id,
+        input.external_id,
+        input.type,
+        input.title,
+        input.status,
+        input.sprint,
+        input.epic,
+        input.points,
+        input.priority,
+        now,
+        now,
+      ]
+    );
+    return toAssignment(rows[0]);
+  }
+
+  /**
+   * Partial update. Returns null when no row matches so callers can 404.
+   * `updated_at` is always bumped server-side.
+   */
+  async updateAssignment(id: string, patch: AssignmentPatch): Promise<Assignment | null> {
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    const push = (column: string, value: unknown) => {
+      params.push(value);
+      sets.push(`${column} = $${params.length}`);
+    };
+
+    if (patch.status !== undefined) push('status', patch.status);
+    if (patch.priority !== undefined) push('priority', patch.priority);
+    if (patch.title !== undefined) push('title', patch.title);
+    if (patch.points !== undefined) push('points', patch.points);
+
+    if (sets.length === 0) {
+      throw new Error('AssignmentPatch must set at least one column');
+    }
+
+    push('updated_at', new Date());
+    params.push(id);
+    const { rows } = await this.db.query<AssignmentRow>(
+      `UPDATE assignments SET ${sets.join(', ')} WHERE id = $${params.length} RETURNING *`,
+      params
     );
     return rows[0] ? toAssignment(rows[0]) : null;
   }

--- a/apps/api/src/tasks/task-write.dto.ts
+++ b/apps/api/src/tasks/task-write.dto.ts
@@ -1,0 +1,111 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  AssignmentPriority,
+  AssignmentPrioritySchema,
+  AssignmentSchema,
+  AssignmentStatus,
+  AssignmentStatusSchema,
+  AssignmentType,
+} from '@worksight/common';
+
+/**
+ * Write-side validation for the task endpoints, derived from the shared
+ * `AssignmentSchema` so the API can never drift from `@worksight/common`.
+ *
+ * Zod is not a direct dependency of the API, so the schema constants stay
+ * module-private: exporting them would force `tsc` to name Zod's inferred
+ * types through `packages/common/node_modules` (TS2742). The exported surface
+ * is the two hand-written input types plus the parse functions.
+ */
+
+/**
+ * `PATCH /tasks/:id` — every field optional, unknown keys stripped.
+ *
+ * `status` / `priority` are re-declared from their bare enums instead of being
+ * `.pick()`ed: the shared schema gives them a `.default()`, and `.partial()`
+ * does **not** drop defaults, so an empty PATCH body would otherwise silently
+ * reset both columns to `todo` / `low`.
+ */
+const UpdateAssignmentSchema = AssignmentSchema.pick({
+  title: true,
+  points: true,
+})
+  .partial()
+  .extend({
+    status: AssignmentStatusSchema.optional(),
+    priority: AssignmentPrioritySchema.optional(),
+  });
+
+/**
+ * `POST /tasks` — Assignment-shaped. `employee_id` and `type` are required, a
+ * supplied `id` must be a UUID (one is generated when missing), and `status` /
+ * `priority` fall back to the shared defaults. Timestamps are server-owned:
+ * `created_at` / `updated_at` in the body are ignored rather than rejected.
+ */
+const CreateAssignmentSchema = AssignmentSchema.omit({
+  created_at: true,
+  updated_at: true,
+}).partial({
+  id: true,
+  source_id: true,
+  external_id: true,
+  title: true,
+  sprint: true,
+  epic: true,
+  points: true,
+});
+
+export type CreateAssignmentInput = {
+  id?: string;
+  employee_id: string;
+  source_id?: string | null;
+  external_id?: string | null;
+  type: AssignmentType;
+  title?: string | null;
+  status: AssignmentStatus;
+  sprint?: string | null;
+  epic?: string | null;
+  points?: number | null;
+  priority: AssignmentPriority;
+};
+
+export type UpdateAssignmentInput = {
+  status?: AssignmentStatus;
+  priority?: AssignmentPriority;
+  title?: string | null;
+  points?: number | null;
+};
+
+export function parseCreateAssignment(body: unknown): CreateAssignmentInput {
+  const parsed = CreateAssignmentSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestException(describeIssues(parsed.error));
+  }
+  assertIntegerPoints(parsed.data.points);
+  return parsed.data;
+}
+
+export function parseUpdateAssignment(body: unknown): UpdateAssignmentInput {
+  const parsed = UpdateAssignmentSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestException(describeIssues(parsed.error));
+  }
+  assertIntegerPoints(parsed.data.points);
+  return parsed.data;
+}
+
+type IssueLike = { path: PropertyKey[]; message: string };
+
+/** Flatten Zod issues into one human-readable line for a 400 response. */
+function describeIssues(error: { issues: readonly IssueLike[] }): string {
+  return error.issues
+    .map(issue => `${issue.path.map(String).join('.') || 'body'}: ${issue.message}`)
+    .join('; ');
+}
+
+/** `points` maps to an integer column; reject floats before Postgres does. */
+function assertIntegerPoints(points: number | null | undefined): void {
+  if (typeof points === 'number' && !Number.isInteger(points)) {
+    throw new BadRequestException('points: expected an integer');
+  }
+}

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -1,12 +1,17 @@
 import {
+  Body,
   Controller,
   Get,
   NotFoundException,
   Param,
   ParseUUIDPipe,
+  Patch,
+  Post,
   Query,
 } from '@nestjs/common';
 import {
+  ApiBody,
+  ApiCreatedResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -47,6 +52,18 @@ export class TasksController {
     return this.tasksService.getStatsForEmployee(employeeId);
   }
 
+  @Post()
+  @ApiOperation({
+    summary: 'Create an assignment',
+    description:
+      'Requires `DATABASE_URL`. Returns 501 in fixture mode. Timestamps are server-owned.',
+  })
+  @ApiBody({ type: AssignmentDto })
+  @ApiCreatedResponse({ type: AssignmentDto })
+  create(@Body() body: unknown): Promise<Assignment> {
+    return this.tasksService.create(body);
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get assignment by id' })
   @ApiParam({ name: 'id', format: 'uuid' })
@@ -58,6 +75,26 @@ export class TasksController {
       throw new NotFoundException(`Task ${id} not found`);
     }
     return assignment;
+  }
+
+  @Patch(':id')
+  @ApiOperation({
+    summary: 'Partial update an assignment',
+    description:
+      'Patch `status`, `priority`, `title`, and/or `points`. Requires `DATABASE_URL` (501 otherwise).',
+  })
+  @ApiParam({ name: 'id', format: 'uuid' })
+  @ApiOkResponse({ type: AssignmentDto })
+  @ApiNotFoundResponse({ description: 'Assignment not found' })
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() body: unknown
+  ): Promise<Assignment> {
+    const updated = await this.tasksService.update(id, body);
+    if (!updated) {
+      throw new NotFoundException(`Task ${id} not found`);
+    }
+    return updated;
   }
 }
 

--- a/apps/api/src/tasks/tasks.service.spec.ts
+++ b/apps/api/src/tasks/tasks.service.spec.ts
@@ -1,4 +1,8 @@
-import { Activities, Assignments } from '@worksight/common';
+import {
+  BadRequestException,
+  NotImplementedException,
+} from '@nestjs/common';
+import { Activities, Assignments, type Assignment } from '@worksight/common';
 import type { WorksightRepository } from '../db/worksight.repository';
 import { TasksService } from './tasks.service';
 
@@ -38,5 +42,138 @@ describe('TasksService', () => {
     const employeeId = Activities[0].employee_id;
     const expected = Activities.filter(a => a.employee_id === employeeId);
     await expect(service.findAllActivities(employeeId)).resolves.toEqual(expected);
+  });
+
+  it('refuses writes in fixture mode with a 501', async () => {
+    await expect(
+      service.create({
+        employee_id: '11111111-1111-4111-8111-111111111111',
+        type: 'bug',
+      })
+    ).rejects.toBeInstanceOf(NotImplementedException);
+    await expect(service.update('any-id', { status: 'completed' })).rejects.toBeInstanceOf(
+      NotImplementedException
+    );
+  });
+});
+
+describe('TasksService writes (postgres backend)', () => {
+  const emp = '22222222-2222-4222-8222-222222222222';
+  const source = '33333333-3333-4333-8333-333333333333';
+
+  const stored: Assignment = {
+    id: '11111111-1111-4111-8111-111111111111',
+    employee_id: emp,
+    source_id: null,
+    external_id: null,
+    type: 'bug',
+    title: 'Fix it',
+    status: 'todo',
+    sprint: null,
+    epic: null,
+    points: 3,
+    priority: 'low',
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    updated_at: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  let createAssignment: jest.Mock;
+  let updateAssignment: jest.Mock;
+  let service: TasksService;
+
+  beforeEach(() => {
+    createAssignment = jest.fn().mockResolvedValue(stored);
+    updateAssignment = jest.fn().mockResolvedValue(stored);
+    service = new TasksService({
+      enabled: true,
+      createAssignment,
+      updateAssignment,
+    } as unknown as WorksightRepository);
+  });
+
+  it('generates a uuid and applies shared defaults when creating', async () => {
+    await expect(service.create({ employee_id: emp, type: 'bug' })).resolves.toEqual(stored);
+
+    const row = createAssignment.mock.calls[0][0];
+    expect(row.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+    expect(row.employee_id).toBe(emp);
+    expect(row.status).toBe('todo');
+    expect(row.priority).toBe('low');
+    expect(row.title).toBeNull();
+    expect(row.points).toBeNull();
+  });
+
+  it('maps a full Assignment-shaped body onto row columns', async () => {
+    await service.create({
+      id: stored.id,
+      employee_id: emp,
+      source_id: source,
+      external_id: 'WS-12',
+      type: 'feature',
+      title: 'Ship it',
+      status: 'in_progress',
+      sprint: 'S1',
+      epic: 'E1',
+      points: 5,
+      priority: 'high',
+      created_at: '1999-01-01T00:00:00Z',
+    });
+
+    expect(createAssignment.mock.calls[0][0]).toMatchObject({
+      id: stored.id,
+      employee_id: emp,
+      source_id: source,
+      external_id: 'WS-12',
+      type: 'feature',
+      title: 'Ship it',
+      status: 'in_progress',
+      sprint: 'S1',
+      epic: 'E1',
+      points: 5,
+      priority: 'high',
+    });
+  });
+
+  it('rejects an invalid create body with a 400', async () => {
+    await expect(service.create({ type: 'bug' })).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.create({ employee_id: emp, type: 'nope' })).rejects.toThrow(/type/);
+    await expect(service.create({ employee_id: emp, type: 'bug', id: 'nope' })).rejects.toThrow(
+      /id/
+    );
+    await expect(
+      service.create({ employee_id: emp, type: 'bug', points: 1.5 })
+    ).rejects.toThrow(/points/);
+    expect(createAssignment).not.toHaveBeenCalled();
+  });
+
+  it('sends only the fields present in a patch', async () => {
+    await expect(service.update(stored.id, { status: 'completed' })).resolves.toEqual(stored);
+    expect(updateAssignment).toHaveBeenCalledWith(stored.id, { status: 'completed' });
+  });
+
+  it('allows nulling title and points, and ignores unknown keys', async () => {
+    await service.update(stored.id, { title: null, points: null, employee_id: emp });
+    expect(updateAssignment).toHaveBeenCalledWith(stored.id, { title: null, points: null });
+  });
+
+  it('does not reset status/priority when the patch omits them', async () => {
+    await service.update(stored.id, { title: 'Renamed' });
+    const patch = updateAssignment.mock.calls[0][1];
+    expect(patch).not.toHaveProperty('status');
+    expect(patch).not.toHaveProperty('priority');
+  });
+
+  it('rejects an empty or invalid patch with a 400', async () => {
+    await expect(service.update(stored.id, {})).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.update(stored.id, { status: 'bogus' })).rejects.toThrow(/status/);
+    await expect(service.update(stored.id, { points: 2.5 })).rejects.toThrow(/points/);
+    expect(updateAssignment).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the id does not exist so the controller can 404', async () => {
+    updateAssignment.mockResolvedValue(null);
+    await expect(service.update('missing', { status: 'todo' })).resolves.toBeNull();
   });
 });

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -1,6 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotImplementedException,
+} from '@nestjs/common';
 import { Activity, ActivityLookup, Assignment, AssignmentLookup } from '@worksight/common';
-import { WorksightRepository } from '../db/worksight.repository';
+import { randomUUID } from 'node:crypto';
+import {
+  AssignmentPatch,
+  NewAssignmentInput,
+  WorksightRepository,
+} from '../db/worksight.repository';
+import { parseCreateAssignment, parseUpdateAssignment } from './task-write.dto';
 
 @Injectable()
 export class TasksService {
@@ -28,7 +38,6 @@ export class TasksService {
 
   async getStatsForEmployee(employeeId: string): Promise<ReturnType<AssignmentLookup['getStats']>> {
     if (this.repo.enabled) {
-      // Same lookup math, hydrated from Postgres instead of the fixtures.
       const [assignments, activities] = await Promise.all([
         this.repo.listAssignments(employeeId),
         this.repo.listActivities(employeeId),
@@ -46,5 +55,58 @@ export class TasksService {
       return this.activities.getActivitiesByEmployee(employeeId).all();
     }
     return this.activities.all();
+  }
+
+  /** `POST /tasks` — persist a new assignment (Postgres only). */
+  async create(body: unknown): Promise<Assignment> {
+    this.requireWritableBackend();
+    const input = parseCreateAssignment(body);
+
+    const row: NewAssignmentInput = {
+      id: input.id ?? randomUUID(),
+      employee_id: input.employee_id,
+      source_id: input.source_id ?? null,
+      external_id: input.external_id ?? null,
+      type: input.type,
+      title: input.title ?? null,
+      status: input.status,
+      sprint: input.sprint ?? null,
+      epic: input.epic ?? null,
+      points: input.points ?? null,
+      priority: input.priority,
+    };
+    return this.repo.createAssignment(row);
+  }
+
+  /** `PATCH /tasks/:id` — returns `null` when the id does not exist. */
+  async update(id: string, body: unknown): Promise<Assignment | null> {
+    this.requireWritableBackend();
+    const input = parseUpdateAssignment(body);
+
+    const patch: AssignmentPatch = {};
+    if (input.status !== undefined) patch.status = input.status;
+    if (input.priority !== undefined) patch.priority = input.priority;
+    if (input.title !== undefined) patch.title = input.title;
+    if (input.points !== undefined) patch.points = input.points;
+
+    if (Object.keys(patch).length === 0) {
+      throw new BadRequestException(
+        'PATCH body must set at least one of: status, priority, title, points'
+      );
+    }
+    return this.repo.updateAssignment(id, patch);
+  }
+
+  /**
+   * Writes need Postgres. Fixture mode is read-only — fail with 501 so clients
+   * do not think a mutation stuck.
+   */
+  private requireWritableBackend(): void {
+    if (!this.repo.enabled) {
+      throw new NotImplementedException(
+        'Task writes require a database backend. Set DATABASE_URL to enable ' +
+          'POST /tasks and PATCH /tasks/:id; fixture mode is read-only.'
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `POST /tasks` and `PATCH /tasks/:id` on top of `WorksightRepository` (raw `pg` / `DATABASE_URL`).
- Fixture mode stays read-only (501) so mutations cannot silently vanish.
- Zod-validated write DTOs aligned with `@worksight/common` Assignment shapes.

Replaces closed #35 (Drizzle stack). Targets the tip of the #28→#32 stack.

## Test plan
- [x] `pnpm --filter @worksight/api test` (28 passed)
- [x] `pnpm --filter @worksight/api type-check`
- [ ] With Neon/`DATABASE_URL`: create + patch a task; GET reflects changes
- [ ] Without `DATABASE_URL`: POST/PATCH return 501


Made with [Cursor](https://cursor.com)