### PR TITLE
fix(mvp): map survey UI ids to Nest question_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ required Vercel dashboard configuration.
 
 ## Contributing
 
-1. Branch from the active integration branch (MVP work stacks on
-   `feat/mvp-stabilize` / `canary` as directed).
+1. Branch from **`canary`** (production integration branch).
 2. Use conventional commits (`feat:`, `fix:`, `docs:`, …).
 3. Keep type-check / lint green for touched packages.
 4. Update docs when behavior or layout changes.

--- a/apps/web/src/lib/mvp-api-bridge.ts
+++ b/apps/web/src/lib/mvp-api-bridge.ts
@@ -312,6 +312,49 @@ export async function fetchMvpSurveysFromApi(): Promise<
 export const DEFAULT_WELLNESS_SURVEY_ID = '277068ac-b7a9-45b5-9d41-f66b017509c7';
 
 /**
+ * Map `/survey` UI string ids → Nest/`@worksight/common` numeric question ids.
+ * Meta fields (`name`, `email`, `role`) are intentionally omitted.
+ * Order matches `SurveyQuestionnaire` in packages/common/src/data/survey.ts.
+ */
+export const UI_TO_API_SURVEY_QUESTION_IDS: Record<string, number> = {
+  workload_1: 0,
+  workload_2: 1,
+  workload_3: 2,
+  workload_4: 3,
+  workload_5: 4,
+  workload_6: 5,
+  balance_1: 6,
+  balance_2: 7,
+  balance_3: 8,
+  balance_4: 9,
+  balance_5: 10,
+  support_1: 11,
+  support_2: 12,
+  support_3: 13,
+  support_4: 14,
+  support_5: 15,
+  engagement_1: 16,
+  engagement_2: 17,
+  engagement_3: 18,
+  engagement_4: 19,
+  engagement_5: 20,
+  engagement_6: 21,
+  engagement_7: 22,
+  engagement_8: 23,
+  engagement_9: 24,
+};
+
+/** Resolve a UI or numeric question id to the API `question_id`. */
+export function mapUiQuestionIdToApi(questionId: string): number | null {
+  if (Object.prototype.hasOwnProperty.call(UI_TO_API_SURVEY_QUESTION_IDS, questionId)) {
+    return UI_TO_API_SURVEY_QUESTION_IDS[questionId]!;
+  }
+  const n = Number(questionId);
+  if (Number.isInteger(n) && n >= 0) return n;
+  return null;
+}
+
+/**
  * Best-effort POST of burnout survey answers to Nest.
  * UI stores keep local history regardless of API success.
  */
@@ -324,9 +367,15 @@ export async function submitWellnessSurveyToApi(input: {
   const employee_id = await resolveApiEmployeeId(input.employeeId);
   const answers = input.responses
     .map(r => {
-      const n = Number(r.questionId);
-      if (!Number.isInteger(n) || n < 0) return null;
-      return { question_id: n, response: r.value };
+      const question_id = mapUiQuestionIdToApi(r.questionId);
+      if (question_id === null) return null;
+      const numeric =
+        typeof r.value === 'number'
+          ? r.value
+          : Number.isFinite(Number(r.value))
+            ? Number(r.value)
+            : r.value;
+      return { question_id, response: numeric };
     })
     .filter((a): a is { question_id: number; response: string | number } => a !== null);
 

--- a/docs/handoffs/2026-08-10-persistence-mvp.md
+++ b/docs/handoffs/2026-08-10-persistence-mvp.md
@@ -1,0 +1,39 @@
+# Handoff: Persistence MVP (Postgres + web writes)
+
+**Date:** 2026-08-10  
+**Branch base:** `canary`  
+**PRs:** #28–#32, #37–#40, survey id-map follow-up
+
+## Outcome
+
+WorkSight MVP can run end-to-end on **Postgres** (local Docker or Neon) with
+the same shapes as `@worksight/common` fixtures. Fixture mode remains the
+default when `DATABASE_URL` is unset.
+
+## Operator path
+
+```bash
+DEMO_WITH_POSTGRES=1 pnpm demo
+# open http://localhost:3000/demo — badge: postgres
+```
+
+Or point `DATABASE_URL` at Neon and run `pnpm --filter @worksight/api seed`.
+
+## Verified surfaces
+
+| Surface | Behavior |
+| --- | --- |
+| `GET /health` | `database: postgres\|fixtures\|unreachable` |
+| Admin users / surveys | Nest when `NEXT_PUBLIC_USE_API=true` |
+| Dashboard tasks | Status drag → `PATCH /tasks/:id` |
+| Survey results | Scale answers → `POST /surveys/:id/responses` via UI→numeric id map |
+| CI | `.github/workflows/api-postgres.yml` |
+
+## Do not merge
+
+Drizzle / `feat/neon-persistence` stacks (#34–#36) — schema conflicts with the
+`pg` + SQL seed path (#28). Prefer `db:reset` if an old Drizzle schema is present.
+
+## Explicit non-goals
+
+Live connectors; production auth hardening.

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -13,3 +13,4 @@ complYaigent `docs/handoffs`.
 | [#19](https://github.com/4sightorg/worksight/issues/19) Docs sync             | [2026-07-25-docs-sync.md](./2026-07-25-docs-sync.md)                           |
 | [#20](https://github.com/4sightorg/worksight/issues/20) Deploy centralization | [2026-07-25-centralize-deployments.md](./2026-07-25-centralize-deployments.md) |
 | — Postgres / PgBouncer for Nest API                                           | [2026-07-26-api-postgres.md](./2026-07-26-api-postgres.md)                     |
+| — Persistence MVP (Postgres + web writes)                                     | [2026-08-10-persistence-mvp.md](./2026-08-10-persistence-mvp.md)               |

--- a/docs/mvp/DEMO.md
+++ b/docs/mvp/DEMO.md
@@ -53,4 +53,7 @@ curl -s http://localhost:3001/tasks | head -c 240; echo
 
 - Live Jira/Trello/GitHub connectors
 - Production auth hardening (Supabase optional; offline demo uses local login)
-- Survey UI question ids that are non-numeric still stay local-only
+
+Survey scale answers use UI ids (`workload_1`, …); the web bridge maps them to
+Nest numeric `question_id` values before `POST /surveys/:id/responses`. Meta
+fields (`name` / `email` / `role`) stay local-only.

--- a/docs/mvp/README.md
+++ b/docs/mvp/README.md
@@ -2,7 +2,7 @@
 
 > **Status:** Persistence MVP landed on `canary` (2026-08-10)  
 > **Epic (fixtures):** [#14](https://github.com/4sightorg/worksight/issues/14)  
-> **Postgres stack:** PRs #28–#32, #37–#39
+> **Postgres stack:** PRs #28–#32, #37–#40 (+ survey UI→API id map)
 
 ## Definition of Done (persistence MVP)
 
@@ -12,6 +12,7 @@
 - [x] Task POST/PATCH
 - [x] CI job seeds Postgres and smokes `/health` + `/users`
 - [x] Web `/demo` shows `database` backend; admin/tasks/surveys use API when `USE_API=true`
+- [x] Survey results map UI question ids → Nest `question_id` and POST responses
 - [x] `pnpm demo` / `DEMO_WITH_POSTGRES=1 pnpm demo` documented
 - [ ] Live connectors (explicit non-goal)
 - [ ] Production auth hardening (explicit non-goal)


### PR DESCRIPTION
## Summary
- Map `/survey` string question ids (`workload_1`, …) to Nest/`@worksight/common` numeric `question_id` values so `POST /surveys/:id/responses` actually persists answers.
- Document persistence MVP DoD + handoff (`docs/handoffs/2026-08-10-persistence-mvp.md`).

## Test plan
- [x] Local Postgres: 25 mapped answers → `201` with `avg_score`
- [x] `PATCH /tasks/:id` still works
- [x] `pnpm --filter @worksight/web type-check`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)