### PR TITLE
fix(mvp): admin surveyCompleted from Nest responses

### DIFF
--- a/apps/web/src/lib/mvp-api-bridge.ts
+++ b/apps/web/src/lib/mvp-api-bridge.ts
@@ -76,20 +76,37 @@ function mapAssignmentPriority(priority: ApiAssignment['priority']): MvpTask['pr
 }
 
 export async function fetchUsersWithMetricsFromApi(): Promise<UserWithMetrics[]> {
-  const [employees, teams, tasks] = await Promise.all([
+  const [employees, teams, tasks, submissions] = await Promise.all([
     worksightApi.getUsers(),
     worksightApi.getTeams(),
     worksightApi.getTasks(),
+    worksightApi.getSurveySubmissions(),
   ]);
+
+  const latestByEmployee = new Map<string, (typeof submissions)[number]>();
+  for (const sub of submissions) {
+    const prev = latestByEmployee.get(sub.employee_id);
+    if (!prev || toDate(sub.submitted_at) > toDate(prev.submitted_at)) {
+      latestByEmployee.set(sub.employee_id, sub);
+    }
+  }
 
   return employees
     .filter(e => e.role !== 'guest')
     .map(employee => {
       const employeeTasks = tasks.filter(t => t.employee_id === employee.id);
       const completedTasks = employeeTasks.filter(t => t.status === 'completed').length;
-      // Approximate wellness without per-employee activity round-trips
-      const openRatio = employeeTasks.length === 0 ? 0 : 1 - completedTasks / employeeTasks.length;
-      const burnoutScore = Math.min(10, Math.round(openRatio * 8 * 10) / 10);
+      const submission = latestByEmployee.get(employee.id);
+      // Prefer persisted survey avg_score (1–5 scale → ~2–10); else open-task ratio.
+      const burnoutScore =
+        submission?.avg_score != null
+          ? Math.min(10, Math.round(submission.avg_score * 2 * 10) / 10)
+          : Math.min(
+              10,
+              Math.round(
+                (employeeTasks.length === 0 ? 0 : 1 - completedTasks / employeeTasks.length) * 8 * 10
+              ) / 10
+            );
 
       return {
         id: employee.id,
@@ -100,7 +117,7 @@ export async function fetchUsersWithMetricsFromApi(): Promise<UserWithMetrics[]>
         team: teamLabel(employee, teams),
         burnoutScore,
         lastActive: relativeTime(toDate(employee.updated_at)),
-        surveyCompleted: false,
+        surveyCompleted: Boolean(submission),
         riskLevel: riskFromBurnout(burnoutScore),
         tasksCompleted: completedTasks,
       };

--- a/docs/mvp/DEMO.md
+++ b/docs/mvp/DEMO.md
@@ -26,7 +26,7 @@ Then open:
 | URL                                   | What you should see                                              |
 | ------------------------------------- | ---------------------------------------------------------------- |
 | http://localhost:3000/demo            | Counts + health badge (`fixtures` / `postgres`) + wellness sample |
-| http://localhost:3000/admin/users     | Users from API                                                   |
+| http://localhost:3000/admin/users     | Users from API; `surveyCompleted` / risk from Nest submissions when present |
 | http://localhost:3000/admin/surveys   | Survey templates from API                                        |
 | http://localhost:3000/dashboard/tasks | Assignment board; status changes PATCH the API when in API mode  |
 | http://localhost:3000/survey          | Wellness survey; results POST to `/surveys/:id/responses`        |


### PR DESCRIPTION
## Summary
- `/admin/users` in API mode now sets `surveyCompleted` from `GET /surveys/responses`.
- When a submission has `avg_score`, prefer it for burnout/risk instead of open-task ratio alone.

## Test plan
- [x] `pnpm --filter @worksight/web type-check`
- [ ] With seeded Postgres + API mode, employees who have submissions show survey completed
- [ ] After submitting `/survey`, refresh `/admin/users` and confirm the submitting employee flips


Made with [Cursor](https://cursor.com)