### PR TITLE
fix(deploy): bake web demo env at Next build time

### DIFF
--- a/apps/web/src/lib/worksight-api.ts
+++ b/apps/web/src/lib/worksight-api.ts
@@ -44,9 +44,14 @@ export function getApiBaseUrl(): string {
   return 'http://localhost:3001';
 }
 
-/** Prefer Nest API when NEXT_PUBLIC_USE_API=true; otherwise local common fixtures. */
+/** Prefer Nest API when NEXT_PUBLIC_USE_API=true; on Vercel, default to API mode. */
 export function getDataSourceMode(): DataSourceMode {
-  return process.env.NEXT_PUBLIC_USE_API === 'true' ? 'api' : 'fixtures';
+  const flag = process.env.NEXT_PUBLIC_USE_API;
+  if (flag === 'true') return 'api';
+  if (flag === 'false') return 'fixtures';
+  // Remote web deploy without an explicit flag → same as local `pnpm demo`.
+  if (process.env.VERCEL) return 'api';
+  return 'fixtures';
 }
 
 export function isApiDataMode(): boolean {

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -5,7 +5,14 @@
   "buildCommand": "pnpm turbo run build --filter=@worksight/web",
   "build": {
     "env": {
-      "NEXT_TELEMETRY_DISABLED": "1"
+      "NEXT_TELEMETRY_DISABLED": "1",
+      "NEXT_PUBLIC_USE_API": "true",
+      "NEXT_PUBLIC_API_URL": "https://worksight-api.vercel.app",
+      "NEXT_PUBLIC_IS_OFFLINE": "true",
+      "IS_OFFLINE": "true",
+      "NEXT_PUBLIC_APP_URL": "https://worksight-web.vercel.app",
+      "NEXT_PUBLIC_APP_NAME": "WorkSight",
+      "NEXT_PUBLIC_APP_DESCRIPTION": "Employee Well-being Analytics Platform"
     }
   },
   "env": {
@@ -13,8 +20,6 @@
     "NEXT_PUBLIC_API_URL": "https://worksight-api.vercel.app",
     "NEXT_PUBLIC_IS_OFFLINE": "true",
     "IS_OFFLINE": "true",
-    "NEXT_PUBLIC_APP_URL": "https://worksight-web.vercel.app",
-    "NEXT_PUBLIC_APP_NAME": "WorkSight",
-    "NEXT_PUBLIC_APP_DESCRIPTION": "Employee Well-being Analytics Platform"
+    "NEXT_PUBLIC_APP_URL": "https://worksight-web.vercel.app"
   }
 }


### PR DESCRIPTION
## Summary
- Move `NEXT_PUBLIC_USE_API` / `NEXT_PUBLIC_API_URL` / offline flags into `build.env` so Next inlines them.
- If the flag is unset on Vercel, default data mode to `api`.

## Test plan
- [ ] After merge, https://worksight-web.vercel.app/demo shows `NEXT_PUBLIC_USE_API` **true** and persistence **postgres**
- [ ] `pnpm demo:remote`


Made with [Cursor](https://cursor.com)