### PR TITLE
MVP gate: API auth + security hardening (#46)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,10 +27,12 @@
     "@nestjs/core": "^11.1.6",
     "@nestjs/platform-express": "^11.1.6",
     "@nestjs/swagger": "^11.2.0",
+    "@nestjs/throttler": "^6.5.0",
     "@supabase/supabase-js": "^2.58.0",
     "@worksight/common": "workspace:*",
     "class-transformer": "^0.5.1",
     "express": "^5.2.1",
+    "helmet": "^8.3.0",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2"

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Header } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiProduces, ApiTags } from '@nestjs/swagger';
+import { Public } from './auth/public.decorator';
 import { DatabaseService } from './db/database.service';
 import { HealthDto } from './openapi/schemas';
 
@@ -8,6 +9,7 @@ import { HealthDto } from './openapi/schemas';
 export class AppController {
   constructor(private readonly db: DatabaseService) {}
 
+  @Public()
   @Get('ping')
   @Header('Content-Type', 'text/plain')
   @ApiOperation({ summary: 'Liveness probe', description: 'Returns plain-text `pong`.' })
@@ -17,6 +19,7 @@ export class AppController {
     return `pong`;
   }
 
+  @Public()
   @Get('health')
   @ApiOperation({
     summary: 'Readiness / data-source check',

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,13 +1,38 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { AppController } from './app.controller';
 import { AttendanceModule } from './attendance/attendance.module';
+import { ApiAuthGuard } from './auth/api-auth.guard';
 import { DatabaseModule } from './db/database.module';
 import { SurveysModule } from './surveys/surveys.module';
 import { TasksModule } from './tasks/tasks.module';
 import { UsersModule } from './users/users.module';
 
 @Module({
-  imports: [DatabaseModule, UsersModule, TasksModule, AttendanceModule, SurveysModule],
+  imports: [
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000,
+        limit: 100,
+      },
+    ]),
+    DatabaseModule,
+    UsersModule,
+    TasksModule,
+    AttendanceModule,
+    SurveysModule,
+  ],
   controllers: [AppController],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: ApiAuthGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/apps/api/src/auth/api-auth.guard.spec.ts
+++ b/apps/api/src/auth/api-auth.guard.spec.ts
@@ -1,0 +1,70 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ApiAuthGuard } from './api-auth.guard';
+
+describe('ApiAuthGuard', () => {
+  let guard: ApiAuthGuard;
+  let reflector: Reflector;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    reflector = new Reflector();
+    guard = new ApiAuthGuard(reflector);
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  function createMockContext(headers: Record<string, string> = {}, isPublic = false): ExecutionContext {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(isPublic);
+    return {
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      switchToHttp: () => ({
+        getRequest: () => ({ headers }),
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  it('allows access when API_REQUIRE_AUTH is not set', () => {
+    delete process.env.API_REQUIRE_AUTH;
+    const context = createMockContext();
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('allows access when API_REQUIRE_AUTH is false', () => {
+    process.env.API_REQUIRE_AUTH = 'false';
+    const context = createMockContext();
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('allows access for public routes when API_REQUIRE_AUTH is true', () => {
+    process.env.API_REQUIRE_AUTH = 'true';
+    const context = createMockContext({}, true);
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('throws UnauthorizedException when auth required but header is missing', () => {
+    process.env.API_REQUIRE_AUTH = 'true';
+    process.env.API_BEARER_TOKEN = 'secret-token';
+    const context = createMockContext({}, false);
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+  });
+
+  it('throws UnauthorizedException when auth required but token is invalid', () => {
+    process.env.API_REQUIRE_AUTH = 'true';
+    process.env.API_BEARER_TOKEN = 'secret-token';
+    const context = createMockContext({ authorization: 'Bearer wrong-token' }, false);
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+  });
+
+  it('allows access when valid Bearer token is provided', () => {
+    process.env.API_REQUIRE_AUTH = 'true';
+    process.env.API_BEARER_TOKEN = 'secret-token';
+    const context = createMockContext({ authorization: 'Bearer secret-token' }, false);
+    expect(guard.canActivate(context)).toBe(true);
+  });
+});

--- a/apps/api/src/auth/api-auth.guard.ts
+++ b/apps/api/src/auth/api-auth.guard.ts
@@ -1,0 +1,41 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from './public.decorator';
+
+@Injectable()
+export class ApiAuthGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requireAuth = (process.env.API_REQUIRE_AUTH ?? '').toLowerCase();
+    const isAuthRequired = requireAuth === 'true' || requireAuth === '1' || requireAuth === 'yes';
+
+    if (!isAuthRequired) {
+      return true;
+    }
+
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers?.authorization;
+    const expectedToken = process.env.API_BEARER_TOKEN;
+
+    if (!authHeader || typeof authHeader !== 'string' || !authHeader.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Missing or invalid Authorization header');
+    }
+
+    const token = authHeader.substring(7).trim();
+    if (!expectedToken || token !== expectedToken) {
+      throw new UnauthorizedException('Invalid API bearer token');
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/auth/public.decorator.ts
+++ b/apps/api/src/auth/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -3,12 +3,25 @@ import { NestFactory, Reflector } from '@nestjs/core';
 import { ExpressAdapter } from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import express, { type Express, type Request, type Response } from 'express';
+import helmet from 'helmet';
 import { AppModule } from './app.module';
+import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
 
 export type BootstrappedApp = {
   app: INestApplication;
   server: Express;
+  corsOrigins: string[];
 };
+
+export function getCorsOrigins(): string[] {
+  const defaultCors = process.env.VERCEL
+    ? 'https://worksight-web.vercel.app,http://localhost:3000'
+    : 'http://localhost:3000';
+  return (process.env.CORS_ORIGINS ?? defaultCors)
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(Boolean);
+}
 
 /**
  * Shared Nest bootstrap for local (`main.ts`) and Vercel (`api/index.ts`).
@@ -21,19 +34,16 @@ export async function createApp(): Promise<BootstrappedApp> {
     logger: ['error', 'warn', 'log'],
   });
 
+  app.use(helmet({ contentSecurityPolicy: false }));
+
   // Local demo: localhost:3000. Vercel: worksight-web (+ local for mixed testing).
-  const defaultCors = process.env.VERCEL
-    ? 'https://worksight-web.vercel.app,http://localhost:3000'
-    : 'http://localhost:3000';
-  const corsOrigins = (process.env.CORS_ORIGINS ?? defaultCors)
-    .split(',')
-    .map(origin => origin.trim())
-    .filter(Boolean);
+  const corsOrigins = getCorsOrigins();
 
   app.enableCors({
     origin: corsOrigins,
     methods: ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE'],
   });
+  app.useGlobalFilters(new GlobalExceptionFilter());
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 
   setupApiDocs(app, server);
@@ -47,7 +57,7 @@ export async function createApp(): Promise<BootstrappedApp> {
     logger.log('Data source: @worksight/common fixtures (set DATABASE_URL to use Postgres).');
   }
 
-  return { app, server };
+  return { app, server, corsOrigins };
 }
 
 /**

--- a/apps/api/src/common/filters/global-exception.filter.spec.ts
+++ b/apps/api/src/common/filters/global-exception.filter.spec.ts
@@ -1,0 +1,63 @@
+import { ArgumentsHost, BadRequestException, HttpStatus } from '@nestjs/common';
+import { GlobalExceptionFilter } from './global-exception.filter';
+
+describe('GlobalExceptionFilter', () => {
+  let filter: GlobalExceptionFilter;
+
+  beforeEach(() => {
+    filter = new GlobalExceptionFilter();
+  });
+
+  function createMockArgumentsHost() {
+    const jsonFn = jest.fn();
+    const statusFn = jest.fn().mockReturnValue({ json: jsonFn });
+
+    const response = { status: statusFn };
+    const request = { method: 'GET', url: '/test-url' };
+
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => response,
+        getRequest: () => request,
+      }),
+    } as unknown as ArgumentsHost;
+
+    return { host, statusFn, jsonFn };
+  }
+
+  it('formats HttpException into standard error envelope', () => {
+    const { host, statusFn, jsonFn } = createMockArgumentsHost();
+    const exception = new BadRequestException('Invalid payload');
+
+    filter.catch(exception, host);
+
+    expect(statusFn).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    expect(jsonFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 400,
+        message: 'Invalid payload',
+        error: 'Bad Request',
+        path: '/test-url',
+        timestamp: expect.any(String),
+      })
+    );
+  });
+
+  it('formats non-HttpException (e.g. raw Error) into 500 error envelope', () => {
+    const { host, statusFn, jsonFn } = createMockArgumentsHost();
+    const exception = new Error('Database connection failed');
+
+    filter.catch(exception, host);
+
+    expect(statusFn).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(jsonFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 500,
+        message: 'Database connection failed',
+        error: 'Internal Server Error',
+        path: '/test-url',
+        timestamp: expect.any(String),
+      })
+    );
+  });
+});

--- a/apps/api/src/common/filters/global-exception.filter.ts
+++ b/apps/api/src/common/filters/global-exception.filter.ts
@@ -1,0 +1,81 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import type { Request, Response } from 'express';
+
+export interface ErrorEnvelope {
+  statusCode: number;
+  message: string | string[];
+  error: string;
+  path: string;
+  timestamp: string;
+}
+
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(GlobalExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    let statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message: string | string[] = 'Internal server error';
+    let error = 'Internal Server Error';
+
+    if (exception instanceof HttpException) {
+      statusCode = exception.getStatus();
+      const res = exception.getResponse();
+
+      if (typeof res === 'string') {
+        message = res;
+        error = exception.name.replace(/Exception$/, '') || 'Error';
+      } else if (typeof res === 'object' && res !== null) {
+        const resObj = res as Record<string, unknown>;
+        message = (resObj.message as string | string[]) ?? exception.message;
+        error = (resObj.error as string | undefined) ?? formatHttpStatusName(statusCode);
+      }
+    } else if (exception instanceof Error) {
+      message = exception.message;
+      error = 'Internal Server Error';
+    }
+
+    const path = request?.url ?? '';
+    const timestamp = new Date().toISOString();
+
+    const logMsg = `${request?.method ?? 'GET'} ${path} - ${statusCode} ${error}: ${
+      Array.isArray(message) ? message.join(', ') : message
+    }`;
+
+    if (statusCode >= 500) {
+      this.logger.error(logMsg, exception instanceof Error ? exception.stack : undefined);
+    } else {
+      this.logger.warn(logMsg);
+    }
+
+    const envelope: ErrorEnvelope = {
+      statusCode,
+      message,
+      error,
+      path,
+      timestamp,
+    };
+
+    response.status(statusCode).json(envelope);
+  }
+}
+
+function formatHttpStatusName(statusCode: number): string {
+  const statusName = HttpStatus[statusCode];
+  if (!statusName) return 'Error';
+  return statusName
+    .split('_')
+    .map(word => word.charAt(0) + word.slice(1).toLowerCase())
+    .join(' ');
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,12 +2,8 @@ import { Logger } from '@nestjs/common';
 import { createApp } from './bootstrap';
 
 async function bootstrap() {
-  const { app } = await createApp();
+  const { app, corsOrigins } = await createApp();
   const port = Number(process.env.PORT ?? 3001);
-  const corsOrigins = (process.env.CORS_ORIGINS ?? 'http://localhost:3000')
-    .split(',')
-    .map(origin => origin.trim())
-    .filter(Boolean);
 
   await app.listen(port);
   Logger.log(

--- a/apps/api/src/security.spec.ts
+++ b/apps/api/src/security.spec.ts
@@ -1,0 +1,75 @@
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { createApp } from './bootstrap';
+
+describe('API Security hardeners (e2e)', () => {
+  let app: INestApplication;
+  const originalEnv = process.env;
+
+  beforeAll(async () => {
+    process.env = { ...originalEnv };
+    const bootstrapped = await createApp();
+    app = bootstrapped.app;
+  });
+
+  afterAll(async () => {
+    process.env = originalEnv;
+    await app.close();
+  });
+
+  it('includes security headers from Helmet', async () => {
+    const res = await request(app.getHttpServer()).get('/ping');
+    expect(res.status).toBe(200);
+    expect(res.headers['x-dns-prefetch-control']).toBe('off');
+    expect(res.headers['x-frame-options']).toBe('SAMEORIGIN');
+    expect(res.headers['strict-transport-security']).toBeDefined();
+  });
+
+  it('returns stable error envelope on 404', async () => {
+    const res = await request(app.getHttpServer()).get('/non-existent-route');
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({
+      statusCode: 404,
+      error: 'Not Found',
+      path: '/non-existent-route',
+      timestamp: expect.any(String),
+    });
+  });
+
+  it('allows access to /ping and /health when API_REQUIRE_AUTH=true', async () => {
+    process.env.API_REQUIRE_AUTH = 'true';
+    process.env.API_BEARER_TOKEN = 'test-token-123';
+
+    const pingRes = await request(app.getHttpServer()).get('/ping');
+    expect(pingRes.status).toBe(200);
+
+    const healthRes = await request(app.getHttpServer()).get('/health');
+    expect(healthRes.status).toBe(200);
+  });
+
+  it('rejects protected routes when API_REQUIRE_AUTH=true and token is missing', async () => {
+    process.env.API_REQUIRE_AUTH = 'true';
+    process.env.API_BEARER_TOKEN = 'test-token-123';
+
+    const res = await request(app.getHttpServer()).get('/users');
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({
+      statusCode: 401,
+      message: 'Missing or invalid Authorization header',
+      error: 'Unauthorized',
+      path: '/users',
+      timestamp: expect.any(String),
+    });
+  });
+
+  it('allows protected routes when valid Bearer token is sent', async () => {
+    process.env.API_REQUIRE_AUTH = 'true';
+    process.env.API_BEARER_TOKEN = 'test-token-123';
+
+    const res = await request(app.getHttpServer())
+      .get('/users')
+      .set('Authorization', 'Bearer test-token-123');
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@nestjs/swagger':
         specifier: ^11.2.0
         version: 11.4.6(@nestjs/common@11.1.28(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(class-transformer@0.5.1)(reflect-metadata@0.2.2)
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@11.1.28(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(reflect-metadata@0.2.2)
       '@supabase/supabase-js':
         specifier: ^2.58.0
         version: 2.110.8
@@ -105,6 +108,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      helmet:
+        specifier: ^8.3.0
+        version: 8.3.0
       pg:
         specifier: ^8.16.3
         version: 8.20.0
@@ -1850,6 +1856,13 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
 
   '@next/bundle-analyzer@15.5.14':
     resolution: {integrity: sha512-Q8rK9QXAqnJ2Ct1XXRJALBccINg9rX0Zl8QSPrYCuL/J1c+k7cfGcRTUNDAP9WIvhYk8JfxZEm1JpcHi+MUKiw==}
@@ -4617,6 +4630,10 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  helmet@8.3.0:
+    resolution: {integrity: sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==}
+    engines: {node: '>=18.0.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -8325,6 +8342,12 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
 
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.28(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.28(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.28)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+
   '@next/bundle-analyzer@15.5.14':
     dependencies:
       webpack-bundle-analyzer: 4.10.1
@@ -11281,6 +11304,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  helmet@8.3.0: {}
 
   hookable@5.5.3: {}
 


### PR DESCRIPTION
Closes #46.

### Summary
- **Optional Bearer Auth Guard**: Implemented `ApiAuthGuard` which enforces bearer token authentication when `API_REQUIRE_AUTH=true`. Compares `Authorization: Bearer <token>` against `API_BEARER_TOKEN`. Excludes `/ping` and `/health` using `@Public()` decorator. When `API_REQUIRE_AUTH` is unset or false, all routes remain public for fixture/offline demo mode.
- **Security Hardening**: Integrated `helmet` (security headers) and `@nestjs/throttler` (rate limiting: 100 requests / min) globally in NestJS `AppModule` / `bootstrap.ts`.
- **Global Exception Filter & Error Envelope**: Catch-all `GlobalExceptionFilter` returning standard envelope `{ statusCode, message, error, path, timestamp }` and logging exceptions via Nest Logger.
- **CORS Single Source of Truth**: Centralized CORS origin resolution in `bootstrap.ts` and refactored `main.ts` to consume `corsOrigins` from `createApp()`.

### Web App Token Configuration (Cross-reference #45)
When `API_REQUIRE_AUTH=true` is enabled in target environment:
1. Configure `API_BEARER_TOKEN` in API environment variables.
2. Web client requests (cross-reference #45) must include header:
   `Authorization: Bearer <API_BEARER_TOKEN>`
